### PR TITLE
Add GCMap React app

### DIFF
--- a/gcmap/.gitignore
+++ b/gcmap/.gitignore
@@ -1,0 +1,2 @@
+# Ignore demo GIF used in README
+public/demo.gif

--- a/gcmap/README.md
+++ b/gcmap/README.md
@@ -1,0 +1,24 @@
+# GCMap
+
+A simple single-page React app for plotting great-circle routes between airports.
+
+## Setup
+
+```bash
+npm install
+npm run dev
+```
+
+Open your browser at the printed local URL.
+
+## Demo
+
+The `public/demo.gif` file is not included in the repository to keep the repo small. You can add your own `demo.gif` locally if you want to showcase the app:
+
+```bash
+# place a demo.gif illustrating the app in gcmap/public/
+```
+
+Type a route such as `SEA-LHR-DXB-SIN` to see arcs drawn on the map and leg-by-leg distances reported below.
+
+This project uses Leaflet, GeographicLib and Tailwind CSS. The airports data is loaded from `public/airports.json` at runtime. Replace it with the full OpenFlights dataset for complete coverage.

--- a/gcmap/index.html
+++ b/gcmap/index.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>GCMap</title>
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <script type="module" src="/src/main.tsx"></script>
+  </head>
+  <body class="h-screen flex flex-col">
+    <div id="root" class="flex-1"></div>
+  </body>
+</html>

--- a/gcmap/package.json
+++ b/gcmap/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "gcmap",
+  "private": true,
+  "version": "0.0.1",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "leaflet": "^1.9.4",
+    "react-leaflet": "^4.2.1",
+    "geographiclib": "^1.55.0",
+    "@turf/turf": "^6.5.0"
+  },
+  "devDependencies": {
+    "@types/react": "^18.0.28",
+    "@types/react-dom": "^18.0.11",
+    "typescript": "^5.4.0",
+    "vite": "^5.0.0",
+    "@vitejs/plugin-react": "^4.0.0",
+    "tailwindcss": "^3.4.1",
+    "autoprefixer": "^10.4.0",
+    "postcss": "^8.4.0"
+  }
+}

--- a/gcmap/postcss.config.js
+++ b/gcmap/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+}

--- a/gcmap/public/airports.json
+++ b/gcmap/public/airports.json
@@ -1,0 +1,12 @@
+[
+  {"iata": "SEA", "name": "Seattle Tacoma Intl", "city": "Seattle", "country": "USA", "latitude": 47.44898, "longitude": -122.30931},
+  {"iata": "LHR", "name": "Heathrow", "city": "London", "country": "United Kingdom", "latitude": 51.4706, "longitude": -0.461941},
+  {"iata": "DXB", "name": "Dubai Intl", "city": "Dubai", "country": "UAE", "latitude": 25.2528, "longitude": 55.3644},
+  {"iata": "SIN", "name": "Changi Intl", "city": "Singapore", "country": "Singapore", "latitude": 1.35019, "longitude": 103.994},
+  {"iata": "JFK", "name": "John F Kennedy Intl", "city": "New York", "country": "USA", "latitude": 40.63975, "longitude": -73.7789},
+  {"iata": "LAX", "name": "Los Angeles Intl", "city": "Los Angeles", "country": "USA", "latitude": 33.9425, "longitude": -118.4081},
+  {"iata": "SFO", "name": "San Francisco Intl", "city": "San Francisco", "country": "USA", "latitude": 37.6188, "longitude": -122.375},
+  {"iata": "DAL", "name": "Dallas Love Field", "city": "Dallas", "country": "USA", "latitude": 32.8471, "longitude": -96.8517},
+  {"iata": "NRT", "name": "Narita Intl", "city": "Tokyo", "country": "Japan", "latitude": 35.7647, "longitude": 140.386},
+  {"iata": "ORD", "name": "Chicago O'Hare Intl", "city": "Chicago", "country": "USA", "latitude": 41.9786, "longitude": -87.9048}
+]

--- a/gcmap/src/App.tsx
+++ b/gcmap/src/App.tsx
@@ -1,0 +1,204 @@
+import React, { useEffect, useState, useRef } from 'react';
+import { MapContainer, TileLayer, Polyline, Circle } from 'react-leaflet';
+import { LatLngExpression, LatLngBounds } from 'leaflet';
+import 'leaflet/dist/leaflet.css';
+import { Geodesic } from 'geographiclib';
+import * as turf from '@turf/turf';
+
+interface Airport {
+  iata: string;
+  name: string;
+  city: string;
+  country: string;
+  latitude: number;
+  longitude: number;
+}
+
+interface CircleDef {
+  code: string;
+  radiusNm: number;
+}
+
+interface Segment {
+  code: string;
+  circle?: CircleDef;
+}
+
+interface LegDistance {
+  nm: number;
+  mi: number;
+  km: number;
+}
+
+interface Leg {
+  from: Airport;
+  to: Airport;
+  dist: LegDistance;
+  path: LatLngExpression[];
+}
+
+const geod = Geodesic.WGS84;
+
+function parseInput(raw: string): Segment[] {
+  const parts = raw
+    .split('-')
+    .map((p) => p.trim().toUpperCase())
+    .filter(Boolean);
+  const segments: Segment[] = [];
+  for (const part of parts) {
+    const circleMatch = part.match(/(\d+)NM@([A-Z]{3})/);
+    if (circleMatch) {
+      segments.push({ code: circleMatch[2], circle: { code: circleMatch[2], radiusNm: parseFloat(circleMatch[1]) } });
+    } else {
+      const code = part;
+      if (segments.length === 0 || segments[segments.length - 1].code !== code) {
+        segments.push({ code });
+      }
+    }
+  }
+  return segments.slice(0, 10);
+}
+
+function calcDistance(a: Airport, b: Airport): LegDistance {
+  const res = geod.Inverse(a.latitude, a.longitude, b.latitude, b.longitude);
+  const meters = res.s12;
+  return {
+    nm: meters / 1852,
+    mi: meters / 1609.344,
+    km: meters / 1000,
+  };
+}
+
+export default function App() {
+  const [airports, setAirports] = useState<Record<string, Airport>>({});
+  const [input, setInput] = useState('');
+  const [legs, setLegs] = useState<Leg[]>([]);
+  const [circles, setCircles] = useState<CircleDef[]>([]);
+  const mapRef = useRef<any>(null);
+
+  useEffect(() => {
+    fetch('/airports.json')
+      .then((r) => r.json())
+      .then((data: Airport[]) => {
+        const dict: Record<string, Airport> = {};
+        data.forEach((a) => {
+          if (a.iata) dict[a.iata.toUpperCase()] = a;
+        });
+        setAirports(dict);
+      });
+  }, []);
+
+  useEffect(() => {
+    const segments = parseInput(input);
+    const newLegs: Leg[] = [];
+    const newCircles: CircleDef[] = [];
+    const missing: string[] = [];
+    let prev: Airport | null = null;
+    for (const seg of segments) {
+      const airport = airports[seg.code];
+      if (!airport) {
+        missing.push(seg.code);
+        continue;
+      }
+      if (prev) {
+        const dist = calcDistance(prev, airport);
+        const line = turf.greatCircle([prev.longitude, prev.latitude], [airport.longitude, airport.latitude], { npoints: 100 });
+        const coords = line.geometry.coordinates.map((c) => [c[1], c[0]] as LatLngExpression);
+        newLegs.push({ from: prev, to: airport, dist, path: coords });
+      }
+      if (seg.circle) {
+        newCircles.push(seg.circle);
+      }
+      prev = airport;
+    }
+    setLegs(newLegs);
+    setCircles(newCircles);
+    if (missing.length > 0) {
+      alert(`Missing airport codes: ${missing.join(', ')}`);
+    }
+  }, [input, airports]);
+
+  useEffect(() => {
+    const map = mapRef.current;
+    if (!map) return;
+    const bounds = new LatLngBounds([]);
+    legs.forEach((leg) => {
+      leg.path.forEach((p) => bounds.extend(p as any));
+    });
+    circles.forEach((c) => {
+      const a = airports[c.code];
+      if (a) bounds.extend([a.latitude, a.longitude]);
+    });
+    if (bounds.isValid()) {
+      map.fitBounds(bounds, { padding: [50, 50] });
+    }
+  }, [legs, circles, airports]);
+
+  const totals = legs.reduce(
+    (acc, l) => ({ nm: acc.nm + l.dist.nm, mi: acc.mi + l.dist.mi, km: acc.km + l.dist.km }),
+    { nm: 0, mi: 0, km: 0 }
+  );
+
+  return (
+    <div className="flex flex-col h-full">
+      <div className="p-4 bg-gray-100 flex items-center gap-2">
+        <input
+          className="border p-2 flex-1"
+          placeholder="Enter route e.g. SEA-LHR-DXB-SIN"
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+        />
+      </div>
+      <div className="flex-1">
+        <MapContainer ref={mapRef} className="w-full h-full" center={[0, 0]} zoom={2} scrollWheelZoom>
+          <TileLayer url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png" />
+          {legs.map((leg, idx) => (
+            <Polyline key={idx} positions={leg.path} pathOptions={{ color: '#d92b2b', weight: 2 }} />
+          ))}
+          {circles.map((c, idx) => {
+            const a = airports[c.code];
+            if (!a) return null;
+            return (
+              <Circle
+                key={`c${idx}`}
+                center={[a.latitude, a.longitude]}
+                radius={c.radiusNm * 1852}
+                pathOptions={{ color: '#d92b2b', weight: 2, fill: false }}
+              />
+            );
+          })}
+        </MapContainer>
+      </div>
+      {legs.length > 0 && (
+        <div className="p-4 overflow-x-auto">
+          <table className="min-w-full text-sm">
+            <thead>
+              <tr className="border-b">
+                <th className="px-2 text-left">Leg</th>
+                <th className="px-2 text-right">Distance (nm)</th>
+                <th className="px-2 text-right">mi</th>
+                <th className="px-2 text-right">km</th>
+              </tr>
+            </thead>
+            <tbody>
+              {legs.map((leg, idx) => (
+                <tr key={idx} className="border-b">
+                  <td className="px-2">{leg.from.iata} → {leg.to.iata}</td>
+                  <td className="px-2 text-right">{leg.dist.nm.toFixed(1)}</td>
+                  <td className="px-2 text-right">{leg.dist.mi.toFixed(1)}</td>
+                  <td className="px-2 text-right">{leg.dist.km.toFixed(1)}</td>
+                </tr>
+              ))}
+              <tr className="font-bold">
+                <td className="px-2">Total</td>
+                <td className="px-2 text-right">{totals.nm.toFixed(1)}</td>
+                <td className="px-2 text-right">{totals.mi.toFixed(1)}</td>
+                <td className="px-2 text-right">{totals.km.toFixed(1)}</td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/gcmap/src/index.css
+++ b/gcmap/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/gcmap/src/main.tsx
+++ b/gcmap/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/gcmap/tailwind.config.js
+++ b/gcmap/tailwind.config.js
@@ -1,0 +1,11 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: [
+    './index.html',
+    './src/**/*.{js,ts,jsx,tsx}'
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+}

--- a/gcmap/tsconfig.json
+++ b/gcmap/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/gcmap/tsconfig.node.json
+++ b/gcmap/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/gcmap/vite.config.ts
+++ b/gcmap/vite.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  build: {
+    outDir: 'dist'
+  }
+});


### PR DESCRIPTION
## Summary
- build gcmap single page React app for mapping great circle routes
- sample airports data and placeholder demo gif
- Leaflet map with geodesic arcs and Tailwind styled results

## Testing
- `npm --prefix gcmap run build` *(fails: `vite` not found)*