### PR TITLE
Switch to airports.dat dataset

### DIFF
--- a/gcmap/README.md
+++ b/gcmap/README.md
@@ -6,4 +6,4 @@ This is a lightweight single-page web app for plotting great-circle flight paths
 
 Open <http://localhost:3000/gcmap/> in your browser.
 
-The app is completely static and pulls Leaflet, Turf.js and Tailwind from public CDNs. For production you may wish to self-host these assets or bundle them locally.
+The app is completely static and pulls Leaflet, Turf.js and Tailwind from public CDNs. Airport locations are parsed client-side from the included `airports.dat` file, which is the full dataset from OurAirports. For production you may wish to self-host the JS/CSS assets or bundle them locally.

--- a/gcmap/main.js
+++ b/gcmap/main.js
@@ -2,8 +2,26 @@ let airportData = {};
 let map, layerGroup;
 
 async function loadAirports() {
-  const res = await fetch('public/airports.json');
-  airportData = await res.json();
+  const res = await fetch('public/airports.dat');
+  const text = await res.text();
+  airportData = {};
+  for (const line of text.trim().split(/\r?\n/)) {
+    if (!line) continue;
+    const parts = line.split(',');
+    if (parts.length < 8) continue;
+    const code = parts[4].replace(/"/g, '');
+    if (!code || code === '\\N') continue;
+    const lat = parseFloat(parts[6]);
+    const lon = parseFloat(parts[7]);
+    if (isNaN(lat) || isNaN(lon)) continue;
+    airportData[code] = {
+      name: parts[1].replace(/"/g, ''),
+      city: parts[2].replace(/"/g, ''),
+      country: parts[3].replace(/"/g, ''),
+      lat,
+      lon
+    };
+  }
 }
 
 function showToast(msg) {


### PR DESCRIPTION
## Summary
- parse `airports.dat` on load and use it for airport data
- document that the full dataset is parsed at runtime

## Testing
- `node - <<'NODE'
const fs = require('fs');
const text = fs.readFileSync('gcmap/public/airports.dat','utf8');
let count=0;let airports={};for(const line of text.trim().split(/\r?\n/)){const p=line.split(',');if(p.length<8)continue;const code=p[4].replace(/"/g,'');if(!code||code==='\\N')continue;airports[code]={lat:parseFloat(p[6]),lon:parseFloat(p[7])};count++;}console.log('airports count',count,'Sample SEA',airports['SEA']);
NODE