### PR TITLE
Fix route parsing and update docs

### DIFF
--- a/gcmap/README.md
+++ b/gcmap/README.md
@@ -1,6 +1,8 @@
 # Great Circle Map
 
-This is a lightweight single-page web app for plotting great-circle flight paths. Enter a series of airport codes (e.g. `SEA-LHR` or `JFK-LAX-SFO`) and see the route drawn on an interactive map along with distance calculations.
+This is a lightweight single-page web app for plotting great-circle flight paths. Enter a series of airport codes (e.g. `SEA-LHR` or `JFK-LAX-SFO`) and see the route drawn on an interactive map along with distance calculations. Circles of equal range can be drawn using the `distance@airport` syntax, e.g. `500nm@SFO`.
+
+Multiple sets of segments can be provided by separating them with spaces, commas or newlines. Sets are not connected to each other when drawn.
 
 ## Setup
 

--- a/gcmap/index.html
+++ b/gcmap/index.html
@@ -15,7 +15,7 @@
   <div class="container mx-auto p-4">
     <h1 class="text-2xl font-bold mb-4">Great Circle Mapper</h1>
     <div class="flex mb-2 gap-2">
-      <textarea id="route-input" rows="3" class="border p-2 flex-grow resize-y" placeholder="Enter route e.g. SEA-LHR or 8000nm@LHR"></textarea>
+      <textarea id="route-input" rows="3" class="border p-2 flex-grow resize-y" placeholder="Enter route e.g. SEA-LHR or 8000nm@LHR. Use spaces, commas or newlines to separate multiple sets"></textarea>
       <button id="draw-btn" class="bg-blue-500 text-white px-4 py-2">Draw</button>
     </div>
     <div class="mb-4">

--- a/gcmap/main.js
+++ b/gcmap/main.js
@@ -48,41 +48,52 @@ function initMap() {
 }
 
 function parseRoute(str) {
-  const parts = str
-    .split(/[-,\n]+/)
-    .map(p => p.trim())
-    .filter(p => p);
-  if (parts.length < 2) {
-    showToast('Enter at least 2 segments');
+  const groups = str
+    .trim()
+    .split(/[\s,]+/)
+    .map(g => g.trim())
+    .filter(g => g);
+
+  if (!groups.length) {
+    showToast('Enter at least one segment');
     return null;
   }
+
   const route = [];
-  for (const part of parts) {
-    const circleMatch = part.match(/^(\d+(?:\.\d+)?)(nm|mi|km)?@([A-Z]{3})$/i);
-    if (circleMatch) {
-      const radius = parseFloat(circleMatch[1]);
-      const units = (circleMatch[2] || 'nm').toLowerCase();
-      const code = circleMatch[3].toUpperCase();
-      const airport = airportData[code];
-      if (!airport) {
-        showToast(`Unknown airport code: ${code}`);
-        return null;
+  for (let gi = 0; gi < groups.length; gi++) {
+    const parts = groups[gi].split(/-/).map(p => p.trim()).filter(p => p);
+    if (!parts.length) continue;
+    for (const part of parts) {
+      const circleMatch = part.match(/^(\d+(?:\.\d+)?)(nm|mi|km)?@([A-Z]{3})$/i);
+      if (circleMatch) {
+        const radius = parseFloat(circleMatch[1]);
+        const units = (circleMatch[2] || 'nm').toLowerCase();
+        const code = circleMatch[3].toUpperCase();
+        const airport = airportData[code];
+        if (!airport) {
+          showToast(`Unknown airport code: ${code}`);
+          return null;
+        }
+        let km = radius;
+        if (units === 'nm') km = nmToKm(radius);
+        else if (units === 'mi') km = miToKm(radius);
+        route.push({ type: 'circle', center: [airport.lat, airport.lon], km });
+      } else {
+        const code = part.toUpperCase();
+        const airport = airportData[code];
+        if (!airport) {
+          showToast(`Unknown airport code: ${code}`);
+          return null;
+        }
+        route.push({ type: 'airport', code, lat: airport.lat, lon: airport.lon });
       }
-      let km = radius;
-      if (units === 'nm') km = nmToKm(radius);
-      else if (units === 'mi') km = miToKm(radius);
-      route.push({ type: 'circle', center: [airport.lat, airport.lon], km });
-    } else {
-      const code = part.toUpperCase();
-      const airport = airportData[code];
-      if (!airport) {
-        showToast(`Unknown airport code: ${code}`);
-        return null;
-      }
-      route.push({ type: 'airport', code, lat: airport.lat, lon: airport.lon });
+    }
+    if (gi < groups.length - 1) {
+      route.push({ type: 'separator' });
     }
   }
-  // remove duplicate consecutive airports
+
+  // remove duplicate consecutive airports within a segment set
   const cleaned = [];
   for (const seg of route) {
     if (seg.type === 'airport') {
@@ -91,6 +102,12 @@ function parseRoute(str) {
     }
     cleaned.push(seg);
   }
+
+  if (!cleaned.length) {
+    showToast('Enter at least one valid segment');
+    return null;
+  }
+
   return cleaned;
 }
 


### PR DESCRIPTION
## Summary
- support separating route sets by comma, whitespace or newline
- ensure route parser adds separators only between sets
- allow equal-range circles using `distance@airport` syntax
- document segment separation in README
- update placeholder hint in map interface

## Testing
- `node - <<'EOF'
const fs=require('fs');
const vm=require('vm');
const file=fs.readFileSync('gcmap/main.js','utf8');
const start=file.indexOf('function parseRoute');
const end=file.indexOf('function drawRoute');
const code=file.slice(start,end);
const ctx={airportData:{SFO:{lat:1,lon:2},SEA:{lat:3,lon:4},LAX:{lat:5,lon:6},CDG:{lat:7,lon:8}},showToast:()=>{},nmToKm:(n)=>n*1.852,miToKm:(n)=>n*1.60934};
vm.runInNewContext(code,ctx);
console.log(ctx.parseRoute('SFO-SEA, LAX-CDG'));
console.log(ctx.parseRoute('500nm@SFO 1000km@CDG'));
console.log(ctx.parseRoute('SFO-SEA LAX-CDG'));
EOF