### PR TITLE
Add airport markers and frequency coloring

### DIFF
--- a/gcmap/index.html
+++ b/gcmap/index.html
@@ -9,6 +9,8 @@
   <style>
     #map { height: 60vh; }
     .toast { position: fixed; top: 1rem; right: 1rem; background: #ef4444; color: white; padding: 0.5rem 1rem; border-radius: 0.25rem; }
+    .airport-label { font-size: 0.75rem; font-weight: bold; }
+    #legend div { width: 20px; height: 20px; }
   </style>
 </head>
 <body class="bg-gray-100">
@@ -22,6 +24,11 @@
       <a href="?file=flight.history.doug.txt" id="doug-link" class="text-blue-500 underline">Doug's flight history</a>
     </div>
     <div id="map" class="mb-4"></div>
+    <div class="flex items-center gap-4 mb-2">
+      <label class="flex items-center gap-1"><input type="checkbox" id="markers-cb" checked> Show airport markers</label>
+      <label class="flex items-center gap-1"><input type="checkbox" id="color-cb" checked> Color by frequency</label>
+    </div>
+    <div id="legend" class="flex items-center gap-1 mb-4"></div>
     <table id="results" class="table-auto w-full text-left border-collapse">
       <thead>
         <tr class="bg-gray-200">

--- a/gcmap/main.js
+++ b/gcmap/main.js
@@ -1,6 +1,12 @@
 let airportData = {};
 let map, layerGroup;
 
+// display options controlled by checkboxes in the UI
+let showMarkers = true;
+let colorByFrequency = true;
+
+const DEFAULT_COLOR = '#d92b2b';
+
 async function loadAirports() {
   const res = await fetch('public/airports.dat');
   const text = await res.text();
@@ -36,6 +42,14 @@ function nmToKm(nm) { return nm * 1.852; }
 function miToKm(mi) { return mi * 1.60934; }
 function kmToNm(km) { return km * 0.539957; }
 function kmToMi(km) { return km * 0.621371; }
+
+// return a color from the jet colormap for a value in [0,1]
+function jetColor(t) {
+  const r = Math.min(1, Math.max(0, Math.min(4 * t - 1.5, -4 * t + 4.5)));
+  const g = Math.min(1, Math.max(0, Math.min(4 * t - 0.5, -4 * t + 3.5)));
+  const b = Math.min(1, Math.max(0, Math.min(4 * t + 0.5, -4 * t + 2.5)));
+  return `rgb(${Math.round(r * 255)},${Math.round(g * 255)},${Math.round(b * 255)})`;
+}
 
 function initMap() {
   map = L.map('map');
@@ -118,15 +132,22 @@ function drawRoute(route) {
   let totalKm = 0;
   const bounds = [];
 
+  const airportSet = new Map();
+  const segmentCounts = {};
+  const segmentLines = {};
+
   for (let i = 0; i < route.length; i++) {
     const seg = route[i];
     if (seg.type === 'circle') {
       const circle = L.circle([seg.center[0], seg.center[1]], {
         radius: seg.km * 1000,
-        color: '#d92b2b',
+        color: DEFAULT_COLOR,
         weight: 2
       }).addTo(layerGroup);
       bounds.push(circle.getBounds());
+    }
+    if (seg.type === 'airport') {
+      airportSet.set(seg.code, [seg.lat, seg.lon]);
     }
   }
 
@@ -139,20 +160,62 @@ function drawRoute(route) {
     const line = turf.greatCircle(from, to, { npoints: 100 });
     const km = turf.length(line, { units: 'kilometers' });
     totalKm += km;
-    L.geoJSON(line, {
-      style: { color: '#d92b2b', weight: 2 }
-    }).addTo(layerGroup);
+
+    const key = [a.code, b.code].sort().join('-');
+    segmentCounts[key] = (segmentCounts[key] || 0) + 1;
+    if (!segmentLines[key]) segmentLines[key] = line;
 
     const nm = kmToNm(km).toFixed(0);
     const mi = kmToMi(km).toFixed(0);
     const kmStr = km.toFixed(0);
     const row = `<tr class="border-b"><td class="p-2">${a.code} → ${b.code}</td><td class="p-2">${nm}</td><td class="p-2">${mi}</td><td class="p-2">${kmStr}</td></tr>`;
     tbody.insertAdjacentHTML('beforeend', row);
-    bounds.push(L.geoJSON(line).getBounds());
   }
 
   const totalRow = `<tr class="font-bold"><td class="p-2">Total</td><td class="p-2">${kmToNm(totalKm).toFixed(0)}</td><td class="p-2">${kmToMi(totalKm).toFixed(0)}</td><td class="p-2">${totalKm.toFixed(0)}</td></tr>`;
   tbody.insertAdjacentHTML('beforeend', totalRow);
+
+  // draw airport markers if enabled
+  if (showMarkers) {
+    for (const [code, coord] of airportSet.entries()) {
+      const marker = L.circleMarker([coord[0], coord[1]], {
+        radius: 4,
+        color: DEFAULT_COLOR,
+        weight: 1,
+        fillOpacity: 1
+      }).addTo(layerGroup);
+      marker.bindTooltip(code, { permanent: true, direction: 'top', className: 'airport-label' });
+      bounds.push(marker.getLatLng());
+    }
+  }
+
+  // draw segments using counts
+  const maxCount = Math.max(...Object.values(segmentCounts), 1);
+  for (const [key, line] of Object.entries(segmentLines)) {
+    const count = segmentCounts[key];
+    let color = DEFAULT_COLOR;
+    if (colorByFrequency && maxCount > 1) {
+      const t = (count - 1) / (maxCount - 1);
+      color = jetColor(t);
+    }
+    const gj = L.geoJSON(line, { style: { color, weight: 2 } }).addTo(layerGroup);
+    bounds.push(gj.getBounds());
+  }
+
+  // update legend
+  const legend = document.getElementById('legend');
+  legend.innerHTML = '';
+  if (colorByFrequency && maxCount > 1) {
+    for (let i = 1; i <= maxCount; i++) {
+      const t = (i - 1) / (maxCount - 1);
+      const swatch = document.createElement('div');
+      swatch.style.width = '20px';
+      swatch.style.height = '20px';
+      swatch.style.background = jetColor(t);
+      swatch.title = `${i}`;
+      legend.appendChild(swatch);
+    }
+  }
 
   if (bounds.length) {
     const combo = bounds[0].extend ? bounds[0] : L.latLngBounds(bounds[0]);
@@ -167,6 +230,21 @@ async function setup() {
   await loadAirports();
   initMap();
   const inputEl = document.getElementById('route-input');
+  const markersCb = document.getElementById('markers-cb');
+  const colorCb = document.getElementById('color-cb');
+
+  showMarkers = markersCb.checked;
+  colorByFrequency = colorCb.checked;
+
+  markersCb.addEventListener('change', () => {
+    showMarkers = markersCb.checked;
+    document.getElementById('draw-btn').click();
+  });
+
+  colorCb.addEventListener('change', () => {
+    colorByFrequency = colorCb.checked;
+    document.getElementById('draw-btn').click();
+  });
   document.getElementById('draw-btn').addEventListener('click', () => {
     const input = inputEl.value.trim().toUpperCase();
     const route = parseRoute(input);


### PR DESCRIPTION
## Summary
- add airport markers and unique segment coloring with Jet colormap
- add UI checkboxes to toggle markers and color scheme
- display legend for segment frequency
- fix marker bounds calculation

## Testing
- `npm test` *(fails: ENOENT no package.json)*
- `npm test` in `gcmap` *(fails: Missing script)*
