### PR TITLE
Use tidy for HTML validation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,9 +9,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Validate HTML
-        run: |
-          curl -s -F "file=@site/index.html;type=text/html" https://validator.w3.org/nu/?out=json | \
-          grep -q '"type":"error"' && { echo "HTML validation failed"; exit 1; } || echo "HTML valid"
+        run: tidy -qe site/index.html
       - name: Copy site to dist
         run: |
           mkdir -p dist

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -10,9 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Validate HTML
-        run: |
-          curl -s -F "file=@site/index.html;type=text/html" https://validator.w3.org/nu/?out=json | \
-          grep -q '"type":"error"' && { echo "HTML validation failed"; exit 1; } || echo "HTML valid"
+        run: tidy -qe site/index.html
       - name: Copy site to dist
         run: |
           mkdir -p dist

--- a/README.md
+++ b/README.md
@@ -18,4 +18,4 @@ Two GitHub Actions workflows keep the site up to date:
 1. **Deploy** – runs on every push to `main`. The action copies `site/` into `dist/` and publishes it to the `gh-pages` branch using `peaceiris/actions-gh-pages`.
 2. **Preview** – runs on pull requests. It also copies `site/` into `dist/` and posts a preview link in the PR via `rossjrw/pr-preview-action`.
 
-The HTML validator step fails the build if `site/index.html` contains validation errors.
+Both workflows run `tidy -qe site/index.html` and fail if linting errors are found.


### PR DESCRIPTION
## Summary
- validate HTML using tidy without installing it in the workflows
- update README about tidy usage

## Testing
- `node site/gcmap/test.js`


------
https://chatgpt.com/codex/tasks/task_e_6844e0fb92b483279e622d6be28637c8