### PR TITLE
Fix leftover comment

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -69,7 +69,6 @@
       }
     }
   </style>
-  <script src="js/three/three.core.min.js"></script>
 </head>
 <body>
   <nav>
@@ -138,7 +137,9 @@
 
   <div id="three-container"></div>
 
-  <script>
+  <script type="module">
+    import * as THREE from './js/three/three.module.min.js';
+
     const container = document.getElementById('three-container');
     const scene = new THREE.Scene();
     const camera = new THREE.PerspectiveCamera(60, container.clientWidth / container.clientHeight, 0.1, 1000);


### PR DESCRIPTION
## Summary
- remove leftover comment after module conversion

## Testing
- `tidy -errors site/index.html`
- `curl -s -F "file=@site/index.html;type=text/html" https://validator.w3.org/nu/?out=json | grep -q '"type":"error"' && { echo "HTML validation failed"; exit 1; } || echo "HTML valid"`

------
https://chatgpt.com/codex/tasks/task_e_6844db7d2694832797776e01b1891537