### PR TITLE
Publish redacted Scandi ECCV 2026 trip

### DIFF
--- a/site/unlisted/scandi-eccv-2026-2a885349b7d5aecf/trip.htm
+++ b/site/unlisted/scandi-eccv-2026-2a885349b7d5aecf/trip.htm
@@ -1,0 +1,4567 @@
+<!DOCTYPE html>
+<html lang="en"><head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="A public, privacy-safe September 2026 family trip guide for Stockholm, ECCV in Malmö, Billund, and Copenhagen.">
+  <meta name="robots" content="noindex,nofollow,noarchive,noimageindex">
+  <meta name="googlebot" content="noindex,nofollow,noarchive,noimageindex">
+  <meta name="referrer" content="no-referrer">
+  <title>Scandi ECCV 2026 · Public Planning Edition</title>
+  <style>
+    :root {
+      --ink: #12263a;
+      --muted: #5e6c77;
+      --paper: #f5f2e9;
+      --paper-deep: #e9e3d5;
+      --surface: #fffdf8;
+      --blue: #075b8d;
+      --blue-dark: #073b57;
+      --sea: #6eb9c7;
+      --sky: #d9edf0;
+      --yellow: #f2c94c;
+      --red: #d45041;
+      --green: #39745a;
+      --orange: #d7853e;
+      --line: #d9d3c5;
+      --shadow: 0 18px 48px rgba(18, 38, 58, 0.10);
+      --shadow-small: 0 8px 22px rgba(18, 38, 58, 0.08);
+      --radius: 18px;
+      --radius-small: 10px;
+      --display: Georgia, "Times New Roman", serif;
+      --sans: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    html {
+      scroll-behavior: smooth;
+    }
+
+    body {
+      margin: 0;
+      background: var(--paper);
+      color: var(--ink);
+      font-family: var(--sans);
+      line-height: 1.55;
+      -webkit-font-smoothing: antialiased;
+    }
+
+    body.modal-lock {
+      overflow: hidden;
+    }
+
+    img {
+      display: block;
+      max-width: 100%;
+    }
+
+    a {
+      color: inherit;
+    }
+
+    button,
+    input {
+      font: inherit;
+    }
+
+    button:focus-visible,
+    a:focus-visible,
+    input:focus-visible {
+      outline: 3px solid var(--yellow);
+      outline-offset: 3px;
+    }
+
+    .wrap {
+      width: min(1180px, calc(100% - 48px));
+      margin: 0 auto;
+    }
+
+    .hero {
+      min-height: 88vh;
+      display: grid;
+      grid-template-columns: minmax(0, 1.03fr) minmax(360px, 0.97fr);
+      background: var(--blue-dark);
+      color: #fff;
+      overflow: hidden;
+    }
+
+    .hero-copy-panel {
+      position: relative;
+      z-index: 2;
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      padding: 86px clamp(42px, 4vw, 72px) 66px max(42px, calc((100vw - 1180px) / 2));
+      background:
+        radial-gradient(circle at 82% 12%, rgba(110, 185, 199, 0.28), transparent 29%),
+        linear-gradient(145deg, #073b57 0%, #082f46 72%, #092b3f 100%);
+    }
+
+    .hero-copy-panel::after {
+      content: "";
+      position: absolute;
+      right: -38px;
+      bottom: 11%;
+      width: 128px;
+      height: 128px;
+      border: 22px solid rgba(242, 201, 76, 0.88);
+      border-radius: 50%;
+      opacity: 0.9;
+      pointer-events: none;
+    }
+
+    .hero-photo {
+      position: relative;
+      min-height: 620px;
+      background:
+        linear-gradient(180deg, rgba(7, 59, 87, 0.04), rgba(7, 59, 87, 0.48)),
+        url("https://commons.wikimedia.org/wiki/Special:FilePath/Oresund%20Bridge%20-%20Malmo%2C%20Sweden.jpg?width=1800") center / cover no-repeat;
+    }
+
+    .hero-photo::before {
+      content: "";
+      position: absolute;
+      inset: 0;
+      background: linear-gradient(90deg, rgba(7, 59, 87, 0.22), transparent 34%);
+    }
+
+    .photo-note {
+      position: absolute;
+      right: 28px;
+      bottom: 26px;
+      max-width: 270px;
+      padding: 14px 16px;
+      border: 1px solid rgba(255, 255, 255, 0.34);
+      border-radius: 12px;
+      background: rgba(7, 38, 55, 0.76);
+      color: rgba(255, 255, 255, 0.9);
+      font-size: 0.79rem;
+      backdrop-filter: blur(10px);
+    }
+
+    .kicker,
+    .eyebrow {
+      margin: 0;
+      color: var(--red);
+      font-size: 0.78rem;
+      font-weight: 900;
+      letter-spacing: 0.13em;
+      text-transform: uppercase;
+    }
+
+    .hero .kicker {
+      color: var(--yellow);
+    }
+
+    h1,
+    h2,
+    h3,
+    p {
+      overflow-wrap: break-word;
+    }
+
+    h1 {
+      max-width: 740px;
+      margin: 16px 0 0;
+      font-family: var(--display);
+      font-size: clamp(3.7rem, 6.6vw, 7rem);
+      font-weight: 500;
+      line-height: 0.9;
+      letter-spacing: -0.055em;
+    }
+
+    h1 span {
+      display: block;
+      margin-top: 12px;
+      color: var(--sea);
+      font-family: var(--sans);
+      font-size: 0.34em;
+      font-weight: 800;
+      letter-spacing: -0.03em;
+      line-height: 1.08;
+    }
+
+    .hero-deck {
+      max-width: 700px;
+      margin: 26px 0 0;
+      color: rgba(255, 255, 255, 0.83);
+      font-size: 1.11rem;
+    }
+
+    .hero-meta {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      margin-top: 26px;
+    }
+
+    .pill {
+      display: inline-flex;
+      align-items: center;
+      min-height: 34px;
+      padding: 6px 11px;
+      border: 1px solid rgba(255, 255, 255, 0.26);
+      border-radius: 999px;
+      background: rgba(255, 255, 255, 0.08);
+      color: #fff;
+      font-size: 0.83rem;
+      font-weight: 760;
+    }
+
+    .hero-actions {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 10px;
+      margin-top: 24px;
+    }
+
+    .button,
+    .scenario-button,
+    .filter-button,
+    .modal-button {
+      min-height: 44px;
+      border: 1px solid transparent;
+      border-radius: 999px;
+      padding: 10px 16px;
+      font-weight: 850;
+      cursor: pointer;
+      transition: transform 160ms ease, background 160ms ease, border-color 160ms ease;
+    }
+
+    .button:hover,
+    .scenario-button:hover,
+    .filter-button:hover,
+    .modal-button:hover {
+      transform: translateY(-1px);
+    }
+
+    .button-primary {
+      background: var(--yellow);
+      color: var(--ink);
+    }
+
+    .button-ghost {
+      border-color: rgba(255, 255, 255, 0.4);
+      background: transparent;
+      color: #fff;
+    }
+
+    .site-nav {
+      position: sticky;
+      top: 0;
+      z-index: 30;
+      border-bottom: 1px solid rgba(217, 211, 197, 0.92);
+      background: rgba(245, 242, 233, 0.94);
+      backdrop-filter: blur(14px);
+    }
+
+    .site-nav .wrap {
+      display: flex;
+      align-items: center;
+      gap: 4px;
+      overflow-x: auto;
+      scrollbar-width: none;
+      padding-top: 9px;
+      padding-bottom: 9px;
+    }
+
+    .site-nav .wrap::-webkit-scrollbar {
+      display: none;
+    }
+
+    .site-nav a {
+      flex: 0 0 auto;
+      padding: 8px 10px;
+      border-radius: 999px;
+      color: var(--muted);
+      font-size: 0.84rem;
+      font-weight: 820;
+      text-decoration: none;
+    }
+
+    .site-nav a:hover {
+      background: var(--paper-deep);
+      color: var(--ink);
+    }
+
+    section {
+      scroll-margin-top: 66px;
+      padding: 82px 0;
+    }
+
+    .section-white {
+      background: var(--surface);
+    }
+
+    .section-blue {
+      background: var(--blue-dark);
+      color: #fff;
+    }
+
+    .section-head {
+      display: grid;
+      grid-template-columns: minmax(0, 1.08fr) minmax(280px, 0.55fr);
+      gap: 40px;
+      align-items: end;
+      margin-bottom: 34px;
+    }
+
+    .section-head h2 {
+      max-width: 760px;
+      margin: 10px 0 0;
+      font-family: var(--display);
+      font-size: clamp(2.45rem, 5vw, 4.6rem);
+      font-weight: 500;
+      line-height: 0.98;
+      letter-spacing: -0.045em;
+    }
+
+    .section-head > p {
+      margin: 0;
+      color: var(--muted);
+      font-size: 0.98rem;
+    }
+
+    .section-blue .section-head > p {
+      color: rgba(255, 255, 255, 0.68);
+    }
+
+    .grid {
+      display: grid;
+      gap: 18px;
+    }
+
+    .grid-2 {
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    .grid-3 {
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+    }
+
+    .grid-4 {
+      grid-template-columns: repeat(4, minmax(0, 1fr));
+    }
+
+    .card {
+      border: 1px solid var(--line);
+      border-radius: var(--radius);
+      background: var(--surface);
+      box-shadow: var(--shadow-small);
+      overflow: hidden;
+    }
+
+    .card-pad {
+      padding: 23px;
+    }
+
+    .stat-card {
+      position: relative;
+      min-height: 190px;
+      display: flex;
+      flex-direction: column;
+      justify-content: space-between;
+      padding: 22px;
+      border-top: 7px solid var(--blue);
+    }
+
+    .stat-card:nth-child(2) {
+      border-top-color: var(--red);
+    }
+
+    .stat-card:nth-child(3) {
+      border-top-color: var(--yellow);
+    }
+
+    .stat-card:nth-child(4) {
+      border-top-color: var(--green);
+    }
+
+    .stat-label {
+      color: var(--muted);
+      font-size: 0.73rem;
+      font-weight: 900;
+      letter-spacing: 0.11em;
+      text-transform: uppercase;
+    }
+
+    .stat-value {
+      margin-top: 12px;
+      font-family: var(--display);
+      font-size: 2rem;
+      line-height: 1;
+      letter-spacing: -0.035em;
+    }
+
+    .stat-note {
+      margin-top: 18px;
+      color: var(--muted);
+      font-size: 0.88rem;
+    }
+
+    .recommendation {
+      display: grid;
+      grid-template-columns: auto minmax(0, 1fr) auto;
+      gap: 18px;
+      align-items: center;
+      margin-top: 24px;
+      padding: 20px 22px;
+      border: 1px solid rgba(7, 91, 141, 0.25);
+      border-left: 8px solid var(--blue);
+      border-radius: var(--radius);
+      background: var(--sky);
+    }
+
+    .recommendation-mark {
+      width: 48px;
+      height: 48px;
+      display: grid;
+      place-items: center;
+      border-radius: 50%;
+      background: var(--blue);
+      color: #fff;
+      font-family: var(--display);
+      font-size: 1.7rem;
+      font-weight: 700;
+    }
+
+    .recommendation h3,
+    .recommendation p {
+      margin: 0;
+    }
+
+    .recommendation h3 {
+      font-size: 1.03rem;
+    }
+
+    .recommendation p {
+      margin-top: 4px;
+      color: #365565;
+      font-size: 0.92rem;
+    }
+
+    .recommendation .tag {
+      white-space: nowrap;
+    }
+
+    .tag {
+      display: inline-flex;
+      align-items: center;
+      width: fit-content;
+      min-height: 27px;
+      padding: 5px 9px;
+      border-radius: 999px;
+      background: #e5f0ec;
+      color: var(--green);
+      font-size: 0.69rem;
+      font-weight: 900;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }
+
+    .tag.blue {
+      background: #e4eef5;
+      color: var(--blue);
+    }
+
+    .tag.red {
+      background: #f9e7e3;
+      color: var(--red);
+    }
+
+    .tag.yellow {
+      background: #fff3bf;
+      color: #785c00;
+    }
+
+    .decision-note {
+      margin: 20px 0 0;
+      padding: 16px 18px;
+      border: 1px dashed #c8bfae;
+      border-radius: var(--radius-small);
+      background: rgba(255, 253, 248, 0.7);
+      color: var(--muted);
+      font-size: 0.9rem;
+    }
+
+    .decision-note strong {
+      color: var(--ink);
+    }
+
+    .scenario-controls {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      margin-bottom: 20px;
+    }
+
+    .scenario-controls[hidden] {
+      display: none;
+    }
+
+    .scenario-button,
+    .filter-button {
+      border-color: var(--line);
+      background: var(--surface);
+      color: var(--muted);
+      font-size: 0.84rem;
+    }
+
+    .scenario-button[aria-pressed="true"],
+    .filter-button[aria-pressed="true"] {
+      border-color: var(--blue);
+      background: var(--blue);
+      color: #fff;
+    }
+
+    .scenario-shell {
+      border: 1px solid var(--line);
+      border-radius: 26px;
+      background: var(--surface);
+      box-shadow: var(--shadow);
+      overflow: hidden;
+    }
+
+    .scenario-top {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) 310px;
+      gap: 28px;
+      align-items: start;
+      padding: 28px;
+      border-bottom: 1px solid var(--line);
+      background: linear-gradient(120deg, #fffdf8 0%, #f2f7f6 100%);
+    }
+
+    .scenario-top h3 {
+      margin: 7px 0 0;
+      font-family: var(--display);
+      font-size: 2.15rem;
+      font-weight: 500;
+      line-height: 1;
+      letter-spacing: -0.035em;
+    }
+
+    .scenario-top p {
+      margin: 12px 0 0;
+      color: var(--muted);
+      font-size: 0.92rem;
+    }
+
+    .scenario-verdict {
+      padding: 17px;
+      border: 1px solid var(--line);
+      border-radius: 14px;
+      background: #fff;
+    }
+
+    .scenario-verdict strong {
+      display: block;
+      font-size: 0.86rem;
+    }
+
+    .scenario-verdict span {
+      display: block;
+      margin-top: 6px;
+      color: var(--muted);
+      font-size: 0.84rem;
+    }
+
+    .route-line {
+      position: relative;
+      display: grid;
+      grid-template-columns: repeat(4, minmax(0, 1fr));
+      gap: 0;
+      padding: 34px 28px 26px;
+    }
+
+    .route-line::before {
+      content: "";
+      position: absolute;
+      top: 50px;
+      left: calc(12.5% + 28px);
+      right: calc(12.5% + 28px);
+      height: 5px;
+      border-radius: 999px;
+      background: linear-gradient(90deg, var(--blue), var(--orange), var(--red), var(--green));
+    }
+
+    .route-stop {
+      position: relative;
+      z-index: 1;
+      text-align: center;
+    }
+
+    .route-dot {
+      width: 36px;
+      height: 36px;
+      display: grid;
+      place-items: center;
+      margin: 0 auto 12px;
+      border: 6px solid var(--surface);
+      border-radius: 50%;
+      background: var(--blue);
+      box-shadow: 0 0 0 2px var(--blue);
+      color: #fff;
+      font-size: 0.62rem;
+      font-weight: 900;
+    }
+
+    .route-stop:nth-child(2) .route-dot {
+      background: var(--orange);
+      box-shadow: 0 0 0 2px var(--orange);
+    }
+
+    .route-stop:nth-child(3) .route-dot {
+      background: var(--red);
+      box-shadow: 0 0 0 2px var(--red);
+    }
+
+    .route-stop:nth-child(4) .route-dot {
+      background: var(--green);
+      box-shadow: 0 0 0 2px var(--green);
+    }
+
+    .route-stop strong {
+      display: block;
+      font-size: 0.94rem;
+    }
+
+    .route-stop span {
+      display: block;
+      margin-top: 3px;
+      color: var(--muted);
+      font-size: 0.77rem;
+    }
+
+    .scenario-days {
+      display: grid;
+      grid-template-columns: repeat(5, minmax(0, 1fr));
+      border-top: 1px solid var(--line);
+    }
+
+    .scenario-day {
+      min-height: 178px;
+      padding: 18px;
+      border-right: 1px solid var(--line);
+      border-bottom: 1px solid var(--line);
+    }
+
+    .scenario-day:nth-child(5n) {
+      border-right: 0;
+    }
+
+    .scenario-day-date {
+      color: var(--red);
+      font-size: 0.71rem;
+      font-weight: 900;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }
+
+    .scenario-day strong {
+      display: block;
+      margin-top: 8px;
+      font-size: 0.96rem;
+      line-height: 1.2;
+    }
+
+    .scenario-day p {
+      margin: 7px 0 0;
+      color: var(--muted);
+      font-size: 0.8rem;
+      line-height: 1.45;
+    }
+
+    .calendar-shell {
+      margin-top: 24px;
+      border: 1px solid var(--line);
+      border-radius: var(--radius);
+      background: var(--surface);
+      box-shadow: var(--shadow-small);
+      overflow: hidden;
+    }
+
+    .calendar-head {
+      display: flex;
+      justify-content: space-between;
+      gap: 20px;
+      align-items: center;
+      padding: 18px 20px;
+      border-bottom: 1px solid var(--line);
+      background: #f1eee5;
+    }
+
+    .calendar-head h3 {
+      margin: 0;
+      font-family: var(--display);
+      font-size: 1.5rem;
+      font-weight: 500;
+    }
+
+    .calendar-head p {
+      margin: 0;
+      color: var(--muted);
+      font-size: 0.8rem;
+    }
+
+    .calendar-grid {
+      display: grid;
+      grid-template-columns: repeat(7, minmax(0, 1fr));
+      gap: 1px;
+      background: var(--line);
+    }
+
+    .calendar-dow,
+    .calendar-day {
+      background: var(--surface);
+    }
+
+    .calendar-dow {
+      padding: 10px 6px;
+      color: var(--muted);
+      font-size: 0.67rem;
+      font-weight: 900;
+      letter-spacing: 0.08em;
+      text-align: center;
+      text-transform: uppercase;
+    }
+
+    .calendar-day {
+      min-height: 92px;
+      padding: 9px;
+      color: var(--muted);
+      font-size: 0.74rem;
+    }
+
+    .calendar-day.empty {
+      background: #f5f2eb;
+    }
+
+    .calendar-day > strong {
+      display: block;
+      color: var(--ink);
+      font-size: 0.78rem;
+    }
+
+    .day-label {
+      display: block;
+      margin-top: 6px;
+      padding: 5px 6px;
+      border-radius: 7px;
+      background: var(--sky);
+      color: var(--blue-dark);
+      font-size: 0.67rem;
+      font-weight: 820;
+      line-height: 1.2;
+    }
+
+    .day-label.travel {
+      background: #f7e8d9;
+      color: #8d4e1d;
+    }
+
+    .day-label.lego {
+      background: #fff0ad;
+      color: #725300;
+    }
+
+    .day-label.conf {
+      background: #dcebf4;
+      color: var(--blue);
+    }
+
+    .day-label.home {
+      background: #e2eee8;
+      color: var(--green);
+    }
+
+    .map-section {
+      background: #e8f0ef;
+    }
+
+    .map-shell {
+      display: grid;
+      grid-template-columns: minmax(0, 1fr) 286px;
+      min-height: 620px;
+      border-radius: 26px;
+      background: var(--blue-dark);
+      box-shadow: var(--shadow);
+      color: #fff;
+      overflow: hidden;
+    }
+
+    .map-stage {
+      position: relative;
+      min-width: 0;
+      min-height: 620px;
+      background:
+        radial-gradient(circle at 42% 56%, rgba(110, 185, 199, 0.22), transparent 34%),
+        linear-gradient(145deg, #0c6687 0%, #084967 58%, #073b57 100%);
+    }
+
+    .map-stage::after {
+      content: "Southern Nordic corridor";
+      position: absolute;
+      left: 22px;
+      bottom: 17px;
+      color: rgba(255, 255, 255, 0.58);
+      font-size: 0.67rem;
+      font-weight: 850;
+      letter-spacing: 0.12em;
+      text-transform: uppercase;
+      pointer-events: none;
+    }
+
+    #nordicMap {
+      display: block;
+      width: 100%;
+      height: 620px;
+    }
+
+    .map-country {
+      fill: #dfe5da;
+      stroke: rgba(7, 59, 87, 0.56);
+      stroke-width: 1.2;
+      vector-effect: non-scaling-stroke;
+    }
+
+    .map-country.is-focus {
+      fill: #f1ead7;
+    }
+
+    .map-route-core,
+    .map-route-stockholm,
+    .map-route-flight {
+      fill: none;
+      stroke-linecap: round;
+      stroke-linejoin: round;
+      vector-effect: non-scaling-stroke;
+    }
+
+    .map-route-core {
+      stroke: var(--yellow);
+      stroke-width: 4.5;
+    }
+
+    .map-route-stockholm {
+      stroke: #f19a82;
+      stroke-width: 4;
+    }
+
+    .map-route-flight {
+      stroke: var(--sea);
+      stroke-width: 2.5;
+      stroke-dasharray: 5 7;
+    }
+
+    .map-marker-halo {
+      fill: rgba(7, 59, 87, 0.24);
+      stroke: #fff;
+      stroke-width: 2;
+      vector-effect: non-scaling-stroke;
+    }
+
+    .map-marker-core {
+      fill: var(--yellow);
+      stroke: var(--blue-dark);
+      stroke-width: 2;
+      vector-effect: non-scaling-stroke;
+    }
+
+    .map-location.is-stockholm .map-marker-core {
+      fill: #f19a82;
+    }
+
+    .map-leader {
+      stroke: rgba(255, 255, 255, 0.7);
+      stroke-width: 1.2;
+      vector-effect: non-scaling-stroke;
+    }
+
+    .map-label {
+      fill: #fff;
+      font-family: var(--sans);
+      font-size: 12px;
+      font-weight: 850;
+      paint-order: stroke;
+      stroke: rgba(7, 59, 87, 0.92);
+      stroke-width: 4px;
+      stroke-linejoin: round;
+    }
+
+    .map-label-note {
+      fill: rgba(255, 255, 255, 0.76);
+      font-size: 10px;
+      font-weight: 700;
+    }
+
+    .map-panel {
+      display: flex;
+      flex-direction: column;
+      justify-content: space-between;
+      gap: 26px;
+      padding: 28px 26px;
+      border-left: 1px solid rgba(255, 255, 255, 0.14);
+      background: rgba(4, 39, 57, 0.76);
+    }
+
+    .map-panel h3 {
+      margin: 0;
+      font-family: var(--display);
+      font-size: 1.65rem;
+      font-weight: 500;
+      line-height: 1.05;
+    }
+
+    .map-panel > div > p {
+      margin: 10px 0 0;
+      color: rgba(255, 255, 255, 0.67);
+      font-size: 0.82rem;
+    }
+
+    .map-legend {
+      display: grid;
+      gap: 14px;
+      margin-top: 26px;
+    }
+
+    .map-key {
+      display: grid;
+      grid-template-columns: 34px minmax(0, 1fr);
+      gap: 10px;
+      align-items: center;
+      font-size: 0.78rem;
+      font-weight: 800;
+    }
+
+    .map-key-line {
+      height: 0;
+      border-top: 4px solid var(--yellow);
+      border-radius: 999px;
+    }
+
+    .map-key-line.stockholm {
+      border-top-color: #f19a82;
+    }
+
+    .map-key-line.flight {
+      border-top: 3px dashed var(--sea);
+    }
+
+    .map-key-dot {
+      width: 14px;
+      height: 14px;
+      margin-left: 10px;
+      border: 3px solid var(--blue-dark);
+      border-radius: 50%;
+      background: var(--yellow);
+      box-shadow: 0 0 0 2px #fff;
+    }
+
+    .map-corridor {
+      padding-top: 22px;
+      border-top: 1px solid rgba(255, 255, 255, 0.15);
+    }
+
+    .map-corridor strong {
+      display: block;
+      color: var(--yellow);
+      font-size: 0.76rem;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }
+
+    .map-corridor p {
+      margin: 7px 0 0;
+      color: rgba(255, 255, 255, 0.74);
+      font-size: 0.8rem;
+    }
+
+    .conference-plan {
+      background: var(--surface);
+    }
+
+    .paper-status {
+      display: grid;
+      grid-template-columns: minmax(0, 1.45fr) minmax(250px, 0.55fr);
+      gap: 28px;
+      align-items: stretch;
+      border-radius: 22px;
+      background: var(--blue-dark);
+      color: #fff;
+      box-shadow: var(--shadow);
+      overflow: hidden;
+    }
+
+    .paper-status-main {
+      padding: 30px;
+    }
+
+    .paper-status-main h3 {
+      max-width: 760px;
+      margin: 12px 0 0;
+      font-family: var(--display);
+      font-size: clamp(1.9rem, 3.2vw, 3.1rem);
+      font-weight: 500;
+      line-height: 1.04;
+      letter-spacing: -0.03em;
+    }
+
+    .paper-status-main p {
+      margin: 15px 0 0;
+      color: rgba(255, 255, 255, 0.7);
+      font-size: 0.9rem;
+    }
+
+    .paper-status-side {
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      padding: 28px;
+      background: rgba(255, 255, 255, 0.08);
+    }
+
+    .paper-status-side strong {
+      color: var(--yellow);
+      font-size: 1.25rem;
+    }
+
+    .paper-status-side span {
+      display: block;
+      margin-top: 7px;
+      color: rgba(255, 255, 255, 0.75);
+      font-size: 0.82rem;
+    }
+
+    .conference-days {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 18px;
+      margin-top: 24px;
+    }
+
+    .conference-day {
+      border: 1px solid var(--line);
+      border-radius: 18px;
+      background: #fbfaf5;
+      box-shadow: var(--shadow-small);
+      overflow: hidden;
+    }
+
+    .conference-day-head {
+      padding: 22px 24px;
+      border-bottom: 1px solid var(--line);
+      background: var(--paper-deep);
+    }
+
+    .conference-day-head h3 {
+      margin: 7px 0 0;
+      font-family: var(--display);
+      font-size: 1.65rem;
+      font-weight: 500;
+      line-height: 1.08;
+    }
+
+    .session-pick {
+      display: grid;
+      grid-template-columns: 82px minmax(0, 1fr);
+      gap: 15px;
+      padding: 20px 24px;
+      border-bottom: 1px solid var(--line);
+    }
+
+    .session-pick:last-child {
+      border-bottom: 0;
+    }
+
+    .session-time {
+      color: var(--red);
+      font-size: 0.72rem;
+      font-weight: 900;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }
+
+    .session-pick h4 {
+      margin: 0;
+      font-size: 0.95rem;
+      line-height: 1.28;
+    }
+
+    .session-pick p {
+      margin: 6px 0 0;
+      color: var(--muted);
+      font-size: 0.8rem;
+    }
+
+    .session-pick a {
+      text-decoration-thickness: 1px;
+      text-underline-offset: 3px;
+    }
+
+    .program-watch {
+      display: grid;
+      grid-template-columns: 280px minmax(0, 1fr);
+      gap: 30px;
+      margin-top: 24px;
+      padding: 28px;
+      border: 1px solid var(--line);
+      border-radius: 20px;
+      background: linear-gradient(120deg, #f2eee3 0%, #eef5f3 100%);
+    }
+
+    .program-watch h3 {
+      margin: 9px 0 0;
+      font-family: var(--display);
+      font-size: 1.75rem;
+      font-weight: 500;
+      line-height: 1.05;
+    }
+
+    .program-watch > div > p {
+      margin: 11px 0 0;
+      color: var(--muted);
+      font-size: 0.84rem;
+    }
+
+    .watch-grid {
+      display: grid;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      gap: 12px;
+    }
+
+    .watch-topic {
+      padding: 16px;
+      border-left: 4px solid var(--sea);
+      background: rgba(255, 255, 255, 0.64);
+    }
+
+    .watch-topic strong {
+      display: block;
+      font-size: 0.84rem;
+      line-height: 1.25;
+    }
+
+    .watch-topic span {
+      display: block;
+      margin-top: 6px;
+      color: var(--muted);
+      font-size: 0.74rem;
+      line-height: 1.4;
+    }
+
+    .commute-check {
+      display: grid;
+      grid-template-columns: minmax(220px, 0.72fr) minmax(0, 1.28fr);
+      gap: 18px;
+      margin-bottom: 24px;
+      padding: 22px;
+      border: 1px solid rgba(255, 255, 255, 0.18);
+      border-radius: var(--radius);
+      background: rgba(255, 255, 255, 0.08);
+    }
+
+    .commute-check h3,
+    .commute-check p {
+      margin: 0;
+    }
+
+    .commute-check h3 {
+      margin-top: 8px;
+      font-family: var(--display);
+      font-size: 1.65rem;
+      font-weight: 500;
+      line-height: 1.05;
+    }
+
+    .commute-check p {
+      margin-top: 9px;
+      color: rgba(255, 255, 255, 0.68);
+      font-size: 0.82rem;
+    }
+
+    .commute-strip {
+      display: grid;
+      grid-template-columns: repeat(4, minmax(0, 1fr));
+      gap: 8px;
+      align-items: stretch;
+    }
+
+    .commute-leg {
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      min-height: 92px;
+      padding: 14px;
+      border-radius: 12px;
+      background: rgba(255, 255, 255, 0.09);
+    }
+
+    .commute-leg strong {
+      color: var(--yellow);
+      font-size: 0.9rem;
+    }
+
+    .commute-leg span {
+      margin-top: 4px;
+      color: rgba(255, 255, 255, 0.68);
+      font-size: 0.71rem;
+      line-height: 1.35;
+    }
+
+    .rail-board {
+      display: grid;
+      grid-template-columns: 330px minmax(0, 1fr);
+      gap: 28px;
+      align-items: start;
+    }
+
+    .rail-spine {
+      position: sticky;
+      top: 86px;
+      padding: 24px;
+      border: 1px solid rgba(255, 255, 255, 0.16);
+      border-radius: var(--radius);
+      background: rgba(255, 255, 255, 0.06);
+    }
+
+    .rail-spine h3 {
+      margin: 0;
+      font-family: var(--display);
+      font-size: 1.55rem;
+      font-weight: 500;
+    }
+
+    .rail-spine > p {
+      margin: 8px 0 22px;
+      color: rgba(255, 255, 255, 0.64);
+      font-size: 0.82rem;
+    }
+
+    .station-list {
+      position: relative;
+      display: grid;
+      gap: 17px;
+    }
+
+    .station-list::before {
+      content: "";
+      position: absolute;
+      top: 15px;
+      bottom: 15px;
+      left: 13px;
+      width: 4px;
+      border-radius: 999px;
+      background: var(--sea);
+    }
+
+    .station {
+      position: relative;
+      display: grid;
+      grid-template-columns: 30px minmax(0, 1fr) auto;
+      gap: 10px;
+      align-items: center;
+    }
+
+    .station-dot {
+      position: relative;
+      z-index: 1;
+      width: 30px;
+      height: 30px;
+      border: 7px solid var(--blue-dark);
+      border-radius: 50%;
+      background: #fff;
+      box-shadow: 0 0 0 2px var(--sea);
+    }
+
+    .station.is-venue .station-dot {
+      background: var(--yellow);
+      box-shadow: 0 0 0 2px var(--yellow);
+    }
+
+    .station strong {
+      display: block;
+      font-size: 0.9rem;
+    }
+
+    .station span {
+      display: block;
+      color: rgba(255, 255, 255, 0.58);
+      font-size: 0.7rem;
+    }
+
+    .station-time {
+      color: var(--yellow);
+      font-size: 0.76rem;
+      font-weight: 900;
+      text-align: right;
+    }
+
+    .base-list {
+      display: grid;
+      gap: 13px;
+    }
+
+    .base-row {
+      display: grid;
+      grid-template-columns: 54px minmax(140px, 0.8fr) minmax(210px, 1.3fr) 118px;
+      gap: 16px;
+      align-items: center;
+      padding: 19px;
+      border: 1px solid rgba(255, 255, 255, 0.15);
+      border-radius: 16px;
+      background: rgba(255, 255, 255, 0.06);
+    }
+
+    .base-rank {
+      width: 42px;
+      height: 42px;
+      display: grid;
+      place-items: center;
+      border-radius: 50%;
+      background: var(--yellow);
+      color: var(--ink);
+      font-family: var(--display);
+      font-size: 1.25rem;
+      font-weight: 700;
+    }
+
+    .base-row h3,
+    .base-row p {
+      margin: 0;
+    }
+
+    .base-row h3 {
+      font-size: 1rem;
+    }
+
+    .base-row p {
+      color: rgba(255, 255, 255, 0.66);
+      font-size: 0.81rem;
+    }
+
+    .base-commute {
+      text-align: right;
+    }
+
+    .base-commute strong {
+      display: block;
+      color: var(--yellow);
+      font-size: 1.08rem;
+    }
+
+    .base-commute span {
+      display: block;
+      color: rgba(255, 255, 255, 0.54);
+      font-size: 0.68rem;
+    }
+
+    .border-warning {
+      margin-top: 18px;
+      padding: 16px 18px;
+      border: 1px solid rgba(242, 201, 76, 0.32);
+      border-left: 6px solid var(--yellow);
+      border-radius: 12px;
+      background: rgba(242, 201, 76, 0.08);
+      color: rgba(255, 255, 255, 0.72);
+      font-size: 0.83rem;
+    }
+
+    .border-warning strong {
+      color: #fff;
+    }
+
+    .filter-row {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px;
+      margin-bottom: 20px;
+    }
+
+    .hotel-grid {
+      display: grid;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      gap: 18px;
+    }
+
+    .hotel-card {
+      position: relative;
+      min-height: 338px;
+      display: flex;
+      flex-direction: column;
+      padding: 22px;
+      border: 1px solid var(--line);
+      border-radius: var(--radius);
+      background: var(--surface);
+      box-shadow: var(--shadow-small);
+      transition: transform 160ms ease, box-shadow 160ms ease;
+    }
+
+    .hotel-card:hover {
+      transform: translateY(-3px);
+      box-shadow: var(--shadow);
+    }
+
+    .hotel-card[hidden] {
+      display: none;
+    }
+
+    .hotel-card[data-booked="true"] {
+      order: -1;
+      border-color: var(--blue);
+      box-shadow: 0 16px 40px rgba(7, 91, 141, 0.18);
+    }
+
+    .hotel-number {
+      position: absolute;
+      top: 18px;
+      right: 18px;
+      color: #d8d1c1;
+      font-family: var(--display);
+      font-size: 2.3rem;
+      line-height: 1;
+    }
+
+    .hotel-card h3 {
+      max-width: 82%;
+      margin: 15px 0 0;
+      font-family: var(--display);
+      font-size: 1.55rem;
+      font-weight: 500;
+      line-height: 1.05;
+      letter-spacing: -0.025em;
+    }
+
+    .hotel-location {
+      margin: 8px 0 0;
+      color: var(--blue);
+      font-size: 0.78rem;
+      font-weight: 850;
+    }
+
+    .hotel-card > p {
+      margin: 13px 0 0;
+      color: var(--muted);
+      font-size: 0.86rem;
+    }
+
+    .amenities {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 6px;
+      margin-top: 16px;
+    }
+
+    .amenity {
+      padding: 5px 8px;
+      border-radius: 6px;
+      background: #f0ede5;
+      color: #5b5b55;
+      font-size: 0.67rem;
+      font-weight: 800;
+    }
+
+    .hotel-bottom {
+      display: flex;
+      justify-content: space-between;
+      gap: 14px;
+      align-items: end;
+      margin-top: auto;
+      padding-top: 18px;
+      border-top: 1px solid var(--line);
+    }
+
+    .hotel-bottom span {
+      color: var(--muted);
+      font-size: 0.7rem;
+    }
+
+    .hotel-bottom strong {
+      display: block;
+      color: var(--ink);
+      font-size: 0.84rem;
+    }
+
+    .hotel-link {
+      color: var(--blue);
+      font-size: 0.77rem;
+      font-weight: 900;
+      text-decoration-thickness: 2px;
+      text-underline-offset: 3px;
+    }
+
+    .shortlist-callout {
+      display: grid;
+      grid-template-columns: minmax(0, 1.25fr) minmax(260px, 0.75fr);
+      gap: 20px;
+      margin-top: 22px;
+      padding: 24px;
+      border: 1px solid var(--line);
+      border-radius: var(--radius);
+      background: var(--blue-dark);
+      color: #fff;
+    }
+
+    .shortlist-callout h3,
+    .shortlist-callout p {
+      margin: 0;
+    }
+
+    .shortlist-callout h3 {
+      font-family: var(--display);
+      font-size: 1.55rem;
+      font-weight: 500;
+    }
+
+    .shortlist-callout p {
+      margin-top: 8px;
+      color: rgba(255, 255, 255, 0.67);
+      font-size: 0.85rem;
+    }
+
+    .shortlist-callout .micro-list {
+      margin: 0;
+      color: rgba(255, 255, 255, 0.76);
+    }
+
+    .family-split {
+      display: grid;
+      grid-template-columns: minmax(0, 0.78fr) minmax(0, 1.22fr);
+      gap: 24px;
+      align-items: start;
+    }
+
+    .conference-ticket {
+      position: sticky;
+      top: 86px;
+      border: 1px solid var(--line);
+      border-radius: var(--radius);
+      background: var(--surface);
+      box-shadow: var(--shadow);
+      overflow: hidden;
+    }
+
+    .ticket-top {
+      padding: 25px;
+      background: var(--blue);
+      color: #fff;
+    }
+
+    .ticket-top .eyebrow {
+      color: var(--yellow);
+    }
+
+    .ticket-top h3 {
+      margin: 9px 0 0;
+      font-family: var(--display);
+      font-size: 2rem;
+      font-weight: 500;
+      line-height: 1;
+    }
+
+    .ticket-top p {
+      margin: 12px 0 0;
+      color: rgba(255, 255, 255, 0.72);
+      font-size: 0.86rem;
+    }
+
+    .ticket-row {
+      display: grid;
+      grid-template-columns: 76px minmax(0, 1fr);
+      gap: 14px;
+      padding: 16px 20px;
+      border-top: 1px dashed var(--line);
+    }
+
+    .ticket-row strong {
+      color: var(--red);
+      font-size: 0.75rem;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }
+
+    .ticket-row span {
+      color: var(--muted);
+      font-size: 0.83rem;
+    }
+
+    .day-plan-list {
+      display: grid;
+      gap: 12px;
+    }
+
+    .day-plan {
+      display: grid;
+      grid-template-columns: 84px minmax(0, 1fr);
+      gap: 18px;
+      padding: 19px;
+      border: 1px solid var(--line);
+      border-radius: 16px;
+      background: var(--surface);
+    }
+
+    .day-plan-date {
+      padding-right: 14px;
+      border-right: 1px solid var(--line);
+    }
+
+    .day-plan-date strong {
+      display: block;
+      color: var(--red);
+      font-family: var(--display);
+      font-size: 1.65rem;
+      font-weight: 500;
+      line-height: 1;
+    }
+
+    .day-plan-date span {
+      display: block;
+      margin-top: 5px;
+      color: var(--muted);
+      font-size: 0.7rem;
+      font-weight: 850;
+      text-transform: uppercase;
+    }
+
+    .day-plan h3,
+    .day-plan p {
+      margin: 0;
+    }
+
+    .day-plan h3 {
+      font-size: 0.98rem;
+    }
+
+    .day-plan p {
+      margin-top: 5px;
+      color: var(--muted);
+      font-size: 0.81rem;
+    }
+
+    .image-feature {
+      display: grid;
+      grid-template-columns: minmax(0, 0.96fr) minmax(0, 1.04fr);
+      min-height: 520px;
+      border-radius: 28px;
+      background: var(--surface);
+      box-shadow: var(--shadow);
+      overflow: hidden;
+    }
+
+    .image-feature-photo {
+      min-height: 480px;
+      background:
+        linear-gradient(180deg, transparent 48%, rgba(13, 41, 50, 0.44)),
+        url("https://commons.wikimedia.org/wiki/Special:FilePath/LEGO%20house%20exterior%2001.jpg?width=1500") center / cover no-repeat;
+    }
+
+    .image-feature-copy {
+      display: flex;
+      flex-direction: column;
+      justify-content: center;
+      padding: 42px;
+    }
+
+    .image-feature-copy h3 {
+      margin: 10px 0 0;
+      font-family: var(--display);
+      font-size: clamp(2.2rem, 4vw, 3.8rem);
+      font-weight: 500;
+      line-height: 0.98;
+      letter-spacing: -0.04em;
+    }
+
+    .image-feature-copy > p {
+      margin: 18px 0 0;
+      color: var(--muted);
+    }
+
+    .opening-pair {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 10px;
+      margin-top: 22px;
+    }
+
+    .opening-card {
+      padding: 15px;
+      border: 1px solid var(--line);
+      border-radius: 12px;
+      background: #f7f3e8;
+    }
+
+    .opening-card strong,
+    .opening-card span {
+      display: block;
+    }
+
+    .opening-card strong {
+      font-size: 0.89rem;
+    }
+
+    .opening-card span {
+      margin-top: 4px;
+      color: var(--muted);
+      font-size: 0.74rem;
+    }
+
+    .opening-card.critical {
+      border-color: rgba(212, 80, 65, 0.4);
+      background: #fcece8;
+    }
+
+    .mini-steps {
+      counter-reset: step;
+      display: grid;
+      grid-template-columns: repeat(4, minmax(0, 1fr));
+      gap: 12px;
+      margin-top: 22px;
+    }
+
+    .mini-step {
+      position: relative;
+      min-height: 154px;
+      padding: 44px 16px 16px;
+      border: 1px solid var(--line);
+      border-radius: 14px;
+      background: var(--surface);
+    }
+
+    .mini-step::before {
+      counter-increment: step;
+      content: counter(step, decimal-leading-zero);
+      position: absolute;
+      top: 14px;
+      left: 16px;
+      color: var(--red);
+      font-family: var(--display);
+      font-size: 1.25rem;
+      font-weight: 700;
+    }
+
+    .mini-step strong {
+      display: block;
+      font-size: 0.88rem;
+    }
+
+    .mini-step span {
+      display: block;
+      margin-top: 6px;
+      color: var(--muted);
+      font-size: 0.75rem;
+    }
+
+    .flight-strategy {
+      display: grid;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      gap: 16px;
+      margin-top: 22px;
+    }
+
+    .strategy-card {
+      padding: 20px;
+      border: 1px solid var(--line);
+      border-radius: 16px;
+      background: var(--surface);
+    }
+
+    .strategy-card.recommended {
+      border-top: 6px solid var(--green);
+    }
+
+    .strategy-card h3,
+    .strategy-card p {
+      margin: 0;
+    }
+
+    .strategy-card h3 {
+      margin-top: 12px;
+      font-size: 1rem;
+    }
+
+    .strategy-card p {
+      margin-top: 8px;
+      color: var(--muted);
+      font-size: 0.81rem;
+    }
+
+    .destination-grid {
+      display: grid;
+      grid-template-columns: 1.2fr repeat(2, minmax(0, 0.8fr));
+      gap: 18px;
+    }
+
+    .destination-card {
+      position: relative;
+      min-height: 355px;
+      display: flex;
+      flex-direction: column;
+      padding: 24px;
+      border: 1px solid var(--line);
+      border-radius: var(--radius);
+      background: var(--surface);
+      box-shadow: var(--shadow-small);
+      overflow: hidden;
+    }
+
+    .destination-card.stockholm {
+      color: #fff;
+      background:
+        linear-gradient(135deg, rgba(7, 59, 87, 0.97), rgba(7, 91, 141, 0.86)),
+        url("https://commons.wikimedia.org/wiki/Special:FilePath/Malm%C3%B6%20central%20station.jpg?width=1200") center / cover no-repeat;
+    }
+
+    .destination-card h3 {
+      margin: 15px 0 0;
+      font-family: var(--display);
+      font-size: 2rem;
+      font-weight: 500;
+      line-height: 1;
+    }
+
+    .destination-card > p {
+      margin: 13px 0 0;
+      color: var(--muted);
+      font-size: 0.86rem;
+    }
+
+    .destination-card.stockholm > p {
+      color: rgba(255, 255, 255, 0.72);
+    }
+
+    .destination-verdict {
+      margin-top: auto;
+      padding-top: 22px;
+    }
+
+    .destination-verdict strong {
+      display: block;
+      font-size: 0.9rem;
+    }
+
+    .destination-verdict span {
+      display: block;
+      margin-top: 5px;
+      color: var(--muted);
+      font-size: 0.77rem;
+    }
+
+    .stockholm .destination-verdict span {
+      color: rgba(255, 255, 255, 0.62);
+    }
+
+    .stamp {
+      position: absolute;
+      top: 24px;
+      right: -24px;
+      width: 130px;
+      padding: 7px 8px;
+      transform: rotate(18deg);
+      border: 2px solid var(--yellow);
+      color: var(--yellow);
+      font-size: 0.66rem;
+      font-weight: 950;
+      letter-spacing: 0.1em;
+      text-align: center;
+      text-transform: uppercase;
+    }
+
+    .booking-summary {
+      display: grid;
+      grid-template-columns: repeat(4, minmax(0, 1fr));
+      gap: 16px;
+      margin-bottom: 24px;
+    }
+
+    .booking-summary-card {
+      min-height: 138px;
+      display: flex;
+      flex-direction: column;
+      justify-content: space-between;
+      padding: 20px;
+      border: 1px solid var(--line);
+      border-radius: var(--radius);
+      background: var(--surface);
+      box-shadow: var(--shadow-small);
+    }
+
+    .booking-summary-card span {
+      color: var(--muted);
+      font-size: 0.72rem;
+      font-weight: 850;
+      letter-spacing: 0.07em;
+      text-transform: uppercase;
+    }
+
+    .booking-summary-card strong {
+      display: block;
+      margin-top: 10px;
+      font-family: var(--display);
+      font-size: clamp(1.65rem, 3vw, 2.35rem);
+      font-weight: 500;
+      line-height: 1;
+    }
+
+    .booking-summary-card p {
+      margin: 10px 0 0;
+      color: var(--muted);
+      font-size: 0.79rem;
+    }
+
+    .booking-ledger {
+      display: grid;
+      gap: 22px;
+      min-width: 0;
+    }
+
+    .booking-group {
+      min-width: 0;
+      padding: 24px;
+      border: 1px solid var(--line);
+      border-radius: var(--radius);
+      background: var(--surface);
+      box-shadow: var(--shadow-small);
+    }
+
+    .booking-group-head {
+      display: flex;
+      flex-wrap: wrap;
+      align-items: start;
+      justify-content: space-between;
+      gap: 14px;
+      padding-bottom: 18px;
+      border-bottom: 1px solid var(--line);
+    }
+
+    .booking-group-head h3,
+    .booking-group-head p {
+      margin: 0;
+    }
+
+    .booking-group-head h3 {
+      font-family: var(--display);
+      font-size: 1.55rem;
+      font-weight: 500;
+    }
+
+    .booking-group-head p {
+      margin-top: 5px;
+      color: var(--muted);
+      font-size: 0.82rem;
+    }
+
+    .booking-reference {
+      padding: 9px 12px;
+      border-radius: 9px;
+      background: var(--blue-dark);
+      color: #fff;
+      font-size: 0.75rem;
+      font-weight: 900;
+      letter-spacing: 0.06em;
+      text-decoration: none;
+      text-transform: uppercase;
+    }
+
+    .flight-booking-grid {
+      display: grid;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      gap: 12px;
+      margin-top: 18px;
+    }
+
+    .flight-leg {
+      padding: 17px;
+      border: 1px solid var(--line);
+      border-radius: 13px;
+      background: #f8f5ed;
+    }
+
+    .flight-leg .flight-date {
+      color: var(--blue);
+      font-size: 0.69rem;
+      font-weight: 950;
+      letter-spacing: 0.07em;
+      text-transform: uppercase;
+    }
+
+    .flight-leg h4 {
+      margin: 8px 0 4px;
+      font-size: 1.05rem;
+      letter-spacing: -0.02em;
+    }
+
+    .flight-leg p {
+      margin: 4px 0;
+      color: var(--muted);
+      font-size: 0.78rem;
+      line-height: 1.45;
+    }
+
+    .booking-detail-list {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 10px 18px;
+      margin: 18px 0 0;
+      padding: 0;
+      list-style: none;
+    }
+
+    .booking-detail-list li {
+      padding-top: 10px;
+      border-top: 1px solid var(--line);
+      color: var(--muted);
+      font-size: 0.8rem;
+    }
+
+    .booking-detail-list strong {
+      display: block;
+      color: var(--ink);
+      font-size: 0.75rem;
+    }
+
+    .cost-table-wrap {
+      min-width: 0;
+      max-width: 100%;
+      margin-top: 18px;
+      overflow-x: auto;
+    }
+
+    .cost-sheet {
+      width: 100%;
+      min-width: 780px;
+      border-collapse: collapse;
+      font-size: 0.82rem;
+      font-variant-numeric: tabular-nums;
+    }
+
+    .cost-sheet th,
+    .cost-sheet td {
+      padding: 11px 12px;
+      border: 1px solid var(--line);
+      text-align: left;
+      vertical-align: top;
+    }
+
+    .cost-sheet th {
+      background: var(--blue-dark);
+      color: #fff;
+      font-size: 0.67rem;
+      letter-spacing: 0.07em;
+      text-transform: uppercase;
+    }
+
+    .cost-sheet .num {
+      text-align: right;
+      white-space: nowrap;
+    }
+
+    .cost-sheet .subtotal-row td {
+      background: #edf3f2;
+      font-weight: 850;
+    }
+
+    .cost-sheet .total-row td {
+      background: var(--yellow);
+      color: var(--ink);
+      font-weight: 950;
+    }
+
+    .cost-sheet .pending {
+      color: var(--orange);
+      font-weight: 850;
+    }
+
+    .decision-table {
+      width: 100%;
+      margin-top: 22px;
+      border-collapse: collapse;
+      border-radius: var(--radius);
+      background: var(--surface);
+      box-shadow: var(--shadow-small);
+      overflow: hidden;
+      font-size: 0.83rem;
+    }
+
+    .decision-table th,
+    .decision-table td {
+      padding: 13px 15px;
+      border-bottom: 1px solid var(--line);
+      text-align: left;
+      vertical-align: top;
+    }
+
+    .decision-table thead th {
+      background: var(--blue-dark);
+      color: #fff;
+      font-size: 0.7rem;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }
+
+    .decision-table tbody tr:last-child td {
+      border-bottom: 0;
+    }
+
+    .decision-table td:not(:first-child) {
+      color: var(--muted);
+    }
+
+    .active-decision {
+      display: grid;
+      grid-template-columns: minmax(0, 1.45fr) minmax(250px, 0.55fr);
+      gap: 24px;
+      margin-bottom: 22px;
+      padding: 28px;
+      border: 2px solid var(--yellow-deep);
+      border-radius: var(--radius);
+      background: #fffaf0;
+      box-shadow: var(--shadow-small);
+    }
+
+    .active-decision h3,
+    .active-decision p {
+      margin: 0;
+    }
+
+    .active-decision h3 {
+      margin-top: 12px;
+      font-family: var(--display);
+      font-size: clamp(1.8rem, 3vw, 2.6rem);
+      font-weight: 500;
+      line-height: 1.04;
+    }
+
+    .active-decision p {
+      margin-top: 12px;
+      color: var(--muted);
+    }
+
+    .decision-action-list {
+      display: grid;
+      gap: 10px;
+      align-content: start;
+      margin: 0;
+      padding: 0;
+      list-style: none;
+    }
+
+    .decision-action-list li {
+      padding: 11px 12px;
+      border: 1px solid var(--line);
+      border-radius: 10px;
+      background: #fff;
+      color: var(--muted);
+      font-size: 0.8rem;
+    }
+
+    .decision-action-list strong {
+      display: block;
+      color: var(--ink);
+    }
+
+    .stockholm-stay-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(245px, 1fr));
+      gap: 18px;
+      margin: 22px 0;
+    }
+
+    .stockholm-stay-card {
+      display: flex;
+      min-width: 0;
+      flex-direction: column;
+      padding: 22px;
+      border: 1px solid var(--line);
+      border-radius: var(--radius);
+      background: var(--surface);
+      box-shadow: var(--shadow-small);
+    }
+
+    .stockholm-stay-card.is-first {
+      border-color: var(--blue);
+      box-shadow: 0 16px 40px rgba(7, 91, 141, 0.14);
+    }
+
+    .stockholm-stay-card h3 {
+      margin: 14px 0 0;
+      font-family: var(--display);
+      font-size: 1.55rem;
+      font-weight: 500;
+      line-height: 1.08;
+    }
+
+    .stockholm-stay-card p {
+      margin: 10px 0 0;
+      color: var(--muted);
+      font-size: 0.84rem;
+    }
+
+    .stockholm-stay-card .hotel-link {
+      align-self: flex-start;
+      margin-top: auto;
+      padding-top: 18px;
+    }
+
+    .jetlag-note {
+      margin: 22px 0;
+      padding: 22px;
+      border-left: 5px solid var(--orange);
+      border-radius: 0 var(--radius) var(--radius) 0;
+      background: #fff5eb;
+    }
+
+    .jetlag-note h3,
+    .jetlag-note p {
+      margin: 0;
+    }
+
+    .jetlag-note h3 {
+      font-family: var(--display);
+      font-size: 1.45rem;
+      font-weight: 500;
+    }
+
+    .jetlag-note p {
+      margin-top: 8px;
+      color: var(--muted);
+    }
+
+    .archive-section {
+      background: #ece8df;
+    }
+
+    .decision-archive-shell {
+      border: 1px solid var(--line);
+      border-radius: var(--radius);
+      background: var(--surface);
+      box-shadow: var(--shadow-small);
+      overflow: hidden;
+    }
+
+    .decision-archive-shell > summary,
+    .archive-item > summary {
+      cursor: pointer;
+      list-style: none;
+    }
+
+    .decision-archive-shell > summary::-webkit-details-marker,
+    .archive-item > summary::-webkit-details-marker {
+      display: none;
+    }
+
+    .decision-archive-shell > summary {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 20px;
+      padding: 22px 24px;
+      font-family: var(--display);
+      font-size: 1.45rem;
+    }
+
+    .decision-archive-shell > summary::after,
+    .archive-item > summary::after {
+      content: "+";
+      color: var(--blue);
+      font-family: var(--sans);
+      font-weight: 900;
+    }
+
+    .decision-archive-shell[open] > summary::after,
+    .archive-item[open] > summary::after {
+      content: "−";
+    }
+
+    .archive-body {
+      display: grid;
+      gap: 18px;
+      padding: 0 24px 24px;
+    }
+
+    .archive-item {
+      border: 1px solid var(--line);
+      border-radius: 12px;
+      background: #f8f5ed;
+      overflow: hidden;
+    }
+
+    .archive-item > summary {
+      display: flex;
+      justify-content: space-between;
+      gap: 16px;
+      padding: 16px 18px;
+      font-weight: 850;
+    }
+
+    .archive-item-copy {
+      padding: 0 18px 18px;
+      color: var(--muted);
+      font-size: 0.84rem;
+    }
+
+    .archive-item-copy ul {
+      margin-bottom: 0;
+    }
+
+    .archive-area-shell {
+      padding: 22px;
+      border-radius: var(--radius);
+      background: var(--blue-dark);
+      color: #fff;
+    }
+
+    .archive-area-shell .rail-board {
+      display: grid;
+      margin: 0;
+    }
+
+    #base .rail-board,
+    #hotels {
+      display: none;
+    }
+
+    #decisionArchiveContent #hotels {
+      display: block;
+      padding: 0;
+      background: transparent;
+    }
+
+    #decisionArchiveContent #hotels > .wrap {
+      width: 100%;
+    }
+
+    .checklist-shell {
+      display: grid;
+      grid-template-columns: 280px minmax(0, 1fr);
+      gap: 28px;
+      align-items: start;
+    }
+
+    .progress-card {
+      position: sticky;
+      top: 86px;
+      padding: 23px;
+      border-radius: var(--radius);
+      background: var(--blue-dark);
+      color: #fff;
+      box-shadow: var(--shadow);
+    }
+
+    .progress-card h3,
+    .progress-card p {
+      margin: 0;
+    }
+
+    .progress-card h3 {
+      font-family: var(--display);
+      font-size: 1.6rem;
+      font-weight: 500;
+    }
+
+    .progress-card p {
+      margin-top: 8px;
+      color: rgba(255, 255, 255, 0.62);
+      font-size: 0.8rem;
+    }
+
+    .progress-number {
+      display: block;
+      margin-top: 22px;
+      color: var(--yellow);
+      font-family: var(--display);
+      font-size: 3.4rem;
+      line-height: 1;
+    }
+
+    .progress-track {
+      height: 8px;
+      margin-top: 13px;
+      border-radius: 999px;
+      background: rgba(255, 255, 255, 0.18);
+      overflow: hidden;
+    }
+
+    .progress-fill {
+      width: 0%;
+      height: 100%;
+      border-radius: inherit;
+      background: var(--yellow);
+      transition: width 180ms ease;
+    }
+
+    .checklist {
+      display: grid;
+      gap: 10px;
+    }
+
+    .check-item {
+      display: grid;
+      grid-template-columns: auto minmax(0, 1fr) auto;
+      gap: 13px;
+      align-items: start;
+      padding: 17px;
+      border: 1px solid var(--line);
+      border-radius: 14px;
+      background: var(--surface);
+    }
+
+    .check-item input {
+      width: 20px;
+      height: 20px;
+      margin: 1px 0 0;
+      accent-color: var(--green);
+      cursor: pointer;
+    }
+
+    .check-copy strong,
+    .check-copy span {
+      display: block;
+    }
+
+    .check-copy strong {
+      font-size: 0.9rem;
+    }
+
+    .check-copy span {
+      margin-top: 4px;
+      color: var(--muted);
+      font-size: 0.76rem;
+    }
+
+    .check-item:has(input:checked) .check-copy strong {
+      color: var(--muted);
+      text-decoration: line-through;
+    }
+
+    .priority {
+      padding: 4px 7px;
+      border-radius: 6px;
+      background: #f5e6df;
+      color: var(--red);
+      font-size: 0.63rem;
+      font-weight: 900;
+      text-transform: uppercase;
+    }
+
+    .priority.soon {
+      background: #fff2bd;
+      color: #735900;
+    }
+
+    .priority.later {
+      background: #e5eee9;
+      color: var(--green);
+    }
+
+    .sources-grid {
+      display: grid;
+      grid-template-columns: repeat(3, minmax(0, 1fr));
+      gap: 16px;
+    }
+
+    .source-group {
+      padding: 20px;
+      border: 1px solid rgba(255, 255, 255, 0.13);
+      border-radius: 16px;
+      background: rgba(255, 255, 255, 0.05);
+    }
+
+    .source-group h3 {
+      margin: 0;
+      color: var(--yellow);
+      font-size: 0.85rem;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+    }
+
+    .source-group ul,
+    .micro-list {
+      margin: 12px 0 0;
+      padding-left: 18px;
+    }
+
+    .source-group li,
+    .micro-list li {
+      margin-top: 7px;
+      color: rgba(255, 255, 255, 0.68);
+      font-size: 0.8rem;
+    }
+
+    .source-group a {
+      text-decoration-color: rgba(255, 255, 255, 0.35);
+      text-underline-offset: 3px;
+    }
+
+    .source-group a:hover {
+      color: #fff;
+    }
+
+    .as-of {
+      margin: 24px 0 0;
+      color: rgba(255, 255, 255, 0.52);
+      font-size: 0.76rem;
+    }
+
+    .modal-overlay {
+      position: fixed;
+      inset: 0;
+      z-index: 100;
+      display: none;
+      place-items: center;
+      padding: 22px;
+      background: rgba(5, 25, 37, 0.78);
+    }
+
+    .modal-overlay.is-open {
+      display: grid;
+    }
+
+    .modal-panel {
+      width: min(960px, 100%);
+      max-height: calc(100vh - 44px);
+      display: flex;
+      flex-direction: column;
+      gap: 13px;
+      padding: 20px;
+      border-radius: var(--radius);
+      background: var(--surface);
+      box-shadow: 0 28px 90px rgba(0, 0, 0, 0.35);
+    }
+
+    .modal-head {
+      display: flex;
+      justify-content: space-between;
+      gap: 20px;
+      align-items: start;
+    }
+
+    .modal-head h2 {
+      margin: 6px 0 0;
+      font-family: var(--display);
+      font-size: 1.75rem;
+      font-weight: 500;
+    }
+
+    .modal-actions {
+      display: flex;
+      gap: 8px;
+    }
+
+    .modal-button {
+      min-height: 40px;
+      border-radius: 10px;
+      padding: 8px 13px;
+      background: #eee9dd;
+      color: var(--ink);
+      font-size: 0.8rem;
+    }
+
+    .modal-button.copy {
+      background: var(--green);
+      color: #fff;
+    }
+
+    .export-text {
+      width: 100%;
+      min-height: min(64vh, 620px);
+      resize: vertical;
+      border: 1px solid var(--line);
+      border-radius: 12px;
+      padding: 14px;
+      background: #f8f6f0;
+      color: var(--ink);
+      font: 0.85rem/1.55 ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+    }
+
+    .visually-hidden {
+      position: absolute !important;
+      width: 1px !important;
+      height: 1px !important;
+      padding: 0 !important;
+      margin: -1px !important;
+      overflow: hidden !important;
+      clip: rect(0, 0, 0, 0) !important;
+      white-space: nowrap !important;
+      border: 0 !important;
+    }
+
+    @media (max-width: 1040px) {
+      .hero {
+        grid-template-columns: 1fr;
+      }
+
+      .hero-copy-panel {
+        min-height: 650px;
+        padding-left: max(32px, calc((100vw - 900px) / 2));
+        padding-right: max(32px, calc((100vw - 900px) / 2));
+      }
+
+      .hero-copy-panel::after {
+        right: 34px;
+        bottom: -64px;
+      }
+
+      .hero-photo {
+        min-height: 440px;
+      }
+
+      .grid-4 {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+      }
+
+      .booking-summary {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+      }
+
+      .scenario-days {
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+      }
+
+      .scenario-day:nth-child(5n) {
+        border-right: 1px solid var(--line);
+      }
+
+      .scenario-day:nth-child(3n) {
+        border-right: 0;
+      }
+
+      .hotel-grid,
+      .sources-grid {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+      }
+
+      .destination-grid {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+      }
+
+      .destination-card.stockholm {
+        grid-column: 1 / -1;
+      }
+    }
+
+    @media (max-width: 820px) {
+      .wrap {
+        width: min(100% - 32px, 700px);
+      }
+
+      section {
+        padding: 66px 0;
+      }
+
+      .section-head,
+      .scenario-top,
+      .active-decision,
+      .map-shell,
+      .rail-board,
+      .paper-status,
+      .conference-days,
+      .program-watch,
+      .watch-grid,
+      .commute-check,
+      .family-split,
+      .image-feature,
+      .shortlist-callout,
+      .checklist-shell {
+        grid-template-columns: 1fr;
+      }
+
+      .booking-summary,
+      .flight-booking-grid {
+        grid-template-columns: 1fr;
+      }
+
+      .booking-detail-list {
+        grid-template-columns: 1fr;
+      }
+
+      .section-head {
+        gap: 18px;
+      }
+
+      .rail-spine,
+      .conference-ticket,
+      .progress-card {
+        position: static;
+      }
+
+      .map-panel {
+        border-top: 1px solid rgba(255, 255, 255, 0.14);
+        border-left: 0;
+      }
+
+      .map-stage,
+      #nordicMap {
+        min-height: 540px;
+        height: 540px;
+      }
+
+      .image-feature-photo {
+        min-height: 380px;
+      }
+
+      .mini-steps,
+      .flight-strategy,
+      .commute-strip {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+      }
+
+      .base-row {
+        grid-template-columns: 48px minmax(0, 1fr) 105px;
+      }
+
+      .base-row > p {
+        grid-column: 2 / -1;
+      }
+
+      .calendar-day {
+        min-height: 80px;
+        padding: 7px;
+      }
+    }
+
+    @media (max-width: 620px) {
+      .hero-copy-panel {
+        min-height: 680px;
+        padding: 72px 24px 54px;
+      }
+
+      .hero-photo {
+        min-height: 340px;
+      }
+
+      .photo-note {
+        right: 16px;
+        bottom: 16px;
+        left: 16px;
+        max-width: none;
+      }
+
+      h1 {
+        font-size: clamp(3.2rem, 18vw, 5rem);
+      }
+
+      .grid-2,
+      .grid-3,
+      .grid-4,
+      .hotel-grid,
+      .sources-grid,
+      .destination-grid,
+      .opening-pair,
+      .mini-steps,
+      .flight-strategy,
+      .commute-strip {
+        grid-template-columns: 1fr;
+      }
+
+      .recommendation {
+        grid-template-columns: auto minmax(0, 1fr);
+      }
+
+      .recommendation .tag {
+        grid-column: 1 / -1;
+      }
+
+      .scenario-top,
+      .route-line,
+      .image-feature-copy {
+        padding: 22px;
+      }
+
+      .route-line {
+        grid-template-columns: 1fr;
+        gap: 18px;
+      }
+
+      .route-line::before {
+        top: 38px;
+        bottom: 38px;
+        left: 40px;
+        right: auto;
+        width: 5px;
+        height: auto;
+        background: linear-gradient(180deg, var(--blue), var(--orange), var(--red), var(--green));
+      }
+
+      .route-stop {
+        display: grid;
+        grid-template-columns: 36px minmax(0, 1fr);
+        column-gap: 14px;
+        text-align: left;
+      }
+
+      .route-dot {
+        grid-row: 1 / span 2;
+        margin: 0;
+      }
+
+      .route-stop span {
+        grid-column: 2;
+      }
+
+      .session-pick {
+        grid-template-columns: 1fr;
+        gap: 7px;
+      }
+
+      .scenario-days {
+        grid-template-columns: 1fr;
+      }
+
+      .scenario-day,
+      .scenario-day:nth-child(3n),
+      .scenario-day:nth-child(5n) {
+        min-height: 0;
+        border-right: 0;
+      }
+
+      .calendar-shell {
+        overflow-x: auto;
+      }
+
+      .calendar-head,
+      .calendar-grid {
+        min-width: 660px;
+      }
+
+      .map-stage,
+      #nordicMap {
+        min-height: 460px;
+        height: 460px;
+      }
+
+      .map-panel {
+        padding: 24px;
+      }
+
+      .map-label {
+        font-size: 11px;
+      }
+
+      .map-label-note {
+        display: none;
+      }
+
+      .base-row {
+        grid-template-columns: 44px minmax(0, 1fr);
+      }
+
+      .base-commute {
+        grid-column: 2;
+        text-align: left;
+      }
+
+      .day-plan {
+        grid-template-columns: 64px minmax(0, 1fr);
+        gap: 13px;
+        padding: 15px;
+      }
+
+      .modal-head {
+        flex-direction: column;
+      }
+
+      .modal-actions {
+        width: 100%;
+      }
+
+      .modal-button {
+        flex: 1;
+      }
+
+      .decision-table {
+        display: block;
+        overflow-x: auto;
+        white-space: nowrap;
+      }
+    }
+
+    @media (prefers-reduced-motion: reduce) {
+      html {
+        scroll-behavior: auto;
+      }
+
+      *,
+      *::before,
+      *::after {
+        transition-duration: 0.01ms !important;
+      }
+    }
+
+    @media print {
+      .site-nav,
+      .hero-actions,
+      .scenario-controls,
+      .filter-row,
+      .modal-overlay {
+        display: none !important;
+      }
+
+      .hero {
+        min-height: auto;
+        grid-template-columns: 1fr;
+      }
+
+      .hero-copy-panel {
+        min-height: auto;
+        padding: 42px;
+      }
+
+      .hero-photo {
+        display: none;
+      }
+
+      section {
+        padding: 36px 0;
+        break-inside: avoid;
+      }
+
+      .rail-spine,
+      .conference-ticket,
+      .progress-card {
+        position: static;
+      }
+
+      .card,
+      .scenario-shell,
+      .hotel-card,
+      .destination-card,
+      .image-feature {
+        box-shadow: none;
+      }
+    }
+  </style>
+</head>
+<body>
+  <header class="hero">
+    <div class="hero-copy-panel">
+      <p class="kicker">Public planning edition · September 2026</p>
+      <h1>A Scandi ECCV 2026<span>Stockholm → Malmö → Billund · nonstop home</span></h1>
+      <p class="hero-deck">A north-to-west Nordic family trip built around ECCV: three nights in Stockholm, a rail-simple conference week in central Malmö, then LEGO country and a Copenhagen launch pad for the nonstop flight home.</p>
+      <div class="hero-meta" aria-label="Trip facts">
+        <span class="pill">September 3–16, 2026</span>
+        <span class="pill">Family of four · two young children</span>
+        <span class="pill">About 8 missed school days</span>
+        <span class="pill">ECCV September 8–12</span>
+        <span class="pill">Flights + Malmö booked · about $8.9k</span>
+      </div>
+      <div class="hero-actions">
+        <a class="button button-primary" href="#verdict">See the recommendation</a>
+        <button class="button button-ghost" id="openExport" type="button">Copy trip brief</button>
+      </div>
+    </div>
+    <div class="hero-photo" role="img" aria-label="The Öresund Bridge connecting Denmark and Sweden">
+      <div class="photo-note">The organizing idea: fly north first, take the train to Malmö, then finish west through Billund and Copenhagen.</div>
+    </div>
+  </header>
+
+  <nav class="site-nav" aria-label="Page sections">
+    <div class="wrap">
+      <a href="#verdict">Verdict</a>
+      <a href="#routes">Route + calendar</a>
+      <a href="#map">Map</a>
+      <a href="#bookings">Booked + costs</a>
+      <a href="#stockholm">Stockholm decision</a>
+      <a href="#base">Malmö commute</a>
+      <a href="#conference">ECCV plan</a>
+      <a href="#family">Malmö family days</a>
+      <a href="#billund">Billund + CPH</a>
+      <a href="#book">Book next</a>
+      <a href="#sources">Sources</a>
+      <a href="#archive">Decision archive</a>
+    </div>
+  </nav>
+
+  <main>
+  <section id="verdict" class="section-white">
+      <div class="wrap">
+        <div class="section-head">
+          <div>
+            <p class="eyebrow">The short answer</p>
+            <h2>Stockholm first. Malmö for ECCV. Billund last. Nonstop home.</h2>
+          </div>
+          <p>The reversed September 3–16 shape is stronger for the family: the only flight connection happens on arrival with a sensible buffer, Stockholm gets two full days, and the final night protects SK935 nonstop to SFO.</p>
+        </div>
+
+        <div class="grid grid-4">
+          <article class="card stat-card">
+            <div>
+              <div class="stat-label">Booked outbound · SK936 + SK1426</div>
+              <div class="stat-value">1h 50m</div>
+            </div>
+            <div class="stat-note">The confirmed itinerary gives 1h50 at CPH between the A350 arrival and SK1426 to Stockholm.</div>
+          </article>
+          <article class="card stat-card">
+            <div>
+              <div class="stat-label">Malmö hotel · booked</div>
+              <div class="stat-value">Baltzar</div>
+            </div>
+            <div class="stat-note">A Junior Suite is confirmed September 7–13 for four guests, with breakfast, fika, and dinner simplifying the conference week.</div>
+          </article>
+          <article class="card stat-card">
+            <div>
+              <div class="stat-label">Trip hinge</div>
+              <div class="stat-value">Sep 13</div>
+            </div>
+            <div class="stat-note">Stay in Malmö through Saturday night, then transfer west Sunday morning. Billund becomes two nights, with a partial park day plus one full LEGO day.</div>
+          </article>
+          <article class="card stat-card">
+            <div>
+              <div class="stat-label">Booked nonstop return · SK935</div>
+              <div class="stat-value">Sep 16</div>
+            </div>
+            <div class="stat-note">The confirmed flight departs Copenhagen at 12:45. Sleep in Copenhagen on September 15 instead of gambling on a same-morning Billund transfer.</div>
+          </article>
+        </div>
+
+        <div class="recommendation">
+          <div class="recommendation-mark" aria-hidden="true">R</div>
+          <div>
+            <h3>Recommended working plan</h3>
+            <p>The SAS flights and Malmö hotel are locked: SK936 and SK1426 to Stockholm, Home Hotel Baltzar September 7–13, then SK935 nonstop home. The active decision is now a jet-lag-friendly Stockholm Central hotel for September 4–7.</p>
+          </div>
+          <span class="tag blue">Best balance</span>
+        </div>
+
+        <p class="decision-note"><strong>Flights confirmed:</strong> SK936 and SK1426 are on one itinerary with a 1 hour 50 minute Copenhagen connection. The return is SK935 nonstop from Copenhagen to San Francisco on September 16. Reservation identifiers are intentionally omitted from this public edition.</p>
+      </div>
+    </section><section id="routes">
+      <div class="wrap">
+        <div class="section-head">
+          <div>
+            <p class="eyebrow">Confirmed trip framework</p>
+            <h2>The flights and six Malmö nights now anchor the calendar.</h2>
+          </div>
+          <p>This is the operating itinerary. Earlier route alternatives have moved to the decision archive; the remaining open choices are Stockholm lodging, the western transfer, and the final Billund–Copenhagen split.</p>
+        </div>
+
+        <div class="scenario-controls" role="group" aria-label="Archived itinerary scenarios" hidden>
+          <button class="scenario-button" type="button" data-scenario="reverse" aria-pressed="true">Recommended · Sep 3–16</button>
+          <button class="scenario-button" type="button" data-scenario="posterSafe" aria-pressed="false">Leave Sep 12 · 3 Billund nights</button>
+          <button class="scenario-button" type="button" data-scenario="billundLate" aria-pressed="false">3 Billund nights · risky return</button>
+        </div>
+
+        <div class="scenario-shell" aria-live="polite">
+          <div class="scenario-top">
+            <div>
+              <span class="tag blue" id="scenarioDates">Sep 3–16 · about 8 school days</span>
+              <h3 id="scenarioTitle">Stockholm, ECCV, Billund, Copenhagen</h3>
+              <p id="scenarioSummary">Three Stockholm nights, six Malmö nights, two Billund nights, and one Copenhagen night before the nonstop home.</p>
+            </div>
+            <div class="scenario-verdict">
+              <strong id="scenarioVerdictTitle">Locked framework</strong>
+              <span id="scenarioVerdictCopy">The booked flights and September 7–13 Baltzar stay protect the conference and preserve the nonstop flight home.</span>
+            </div>
+          </div>
+          <div class="route-line" id="scenarioRoute" aria-label="Selected scenario route">
+        <div class="route-stop">
+          <div class="route-dot">01</div>
+          <strong>Stockholm</strong>
+          <span>Sep 4–7 · 3 nights</span>
+        </div>
+        <div class="route-stop">
+          <div class="route-dot">02</div>
+          <strong>Malmö</strong>
+          <span>Sep 7–13 · Baltzar + ECCV</span>
+        </div>
+        <div class="route-stop">
+          <div class="route-dot">03</div>
+          <strong>Billund</strong>
+          <span>Sep 13–15 · 2 nights</span>
+        </div>
+        <div class="route-stop">
+          <div class="route-dot">04</div>
+          <strong>Copenhagen → SFO</strong>
+          <span>Sep 15–16 · SK935 nonstop</span>
+        </div></div>
+          <div class="scenario-days" id="scenarioDays">
+        <article class="scenario-day">
+          <div class="scenario-day-date">Thu–Fri · Sep 3–4</div>
+          <strong>SK936 + SK1426</strong>
+          <p>Confirmed SFO → CPH → ARN itinerary, with SK1426 at 13:50–15:05 and a 1h50 protected connection.</p>
+        </article>
+        <article class="scenario-day">
+          <div class="scenario-day-date">Fri–Mon · Sep 4–7</div>
+          <strong>Stockholm</strong>
+          <p>Gamla Stan arrival walk, Vasa + Djurgården, then one flexible family day.</p>
+        </article>
+        <article class="scenario-day">
+          <div class="scenario-day-date">Mon · Sep 7</div>
+          <strong>Train to Malmö</strong>
+          <p>Direct X 2000 takes about 4½ hours; current family fares are roughly SEK 2,200–3,500.</p>
+        </article>
+        <article class="scenario-day">
+          <div class="scenario-day-date">Tue–Sat · Sep 8–12</div>
+          <strong>ECCV</strong>
+          <p>Direct Malmö C → Hyllie commute; sleep in Malmö after the final program.</p>
+        </article>
+        <article class="scenario-day">
+          <div class="scenario-day-date">Sun · Sep 13</div>
+          <strong>Malmö → LEGOLAND</strong>
+          <p>Transfer early and use a partial park day; official hours are 10:00–18:00.</p>
+        </article>
+        <article class="scenario-day">
+          <div class="scenario-day-date">Mon · Sep 14</div>
+          <strong>LEGO House</strong>
+          <p>Book a full 10:00–16:00 visit.</p>
+        </article>
+        <article class="scenario-day">
+          <div class="scenario-day-date">Tue–Wed · Sep 15–16</div>
+          <strong>Copenhagen + SK935</strong>
+          <p>Move east Tuesday, sleep in Copenhagen, and fly nonstop Wednesday.</p>
+        </article></div>
+        </div>
+
+        <div class="calendar-shell" aria-label="September 2026 trip calendar">
+          <div class="calendar-head">
+            <h3>September 2026</h3>
+            <p>Monday-first calendar · current September 3–16 itinerary</p>
+          </div>
+          <div class="calendar-grid">
+            <div class="calendar-dow">Mon</div><div class="calendar-dow">Tue</div><div class="calendar-dow">Wed</div><div class="calendar-dow">Thu</div><div class="calendar-dow">Fri</div><div class="calendar-dow">Sat</div><div class="calendar-dow">Sun</div>
+            <div class="calendar-day empty"></div>
+            <div class="calendar-day"><strong>1</strong></div>
+            <div class="calendar-day"><strong>2</strong></div>
+            <div class="calendar-day"><strong>3</strong><span class="day-label travel">SK936 · depart SFO</span></div>
+            <div class="calendar-day"><strong>4</strong><span class="day-label travel">SK1426 → Stockholm</span></div>
+            <div class="calendar-day"><strong>5</strong><span class="day-label home">Vasa + Djurgården</span></div>
+            <div class="calendar-day"><strong>6</strong><span class="day-label home">Stockholm day 2</span></div>
+            <div class="calendar-day"><strong>7</strong><span class="day-label travel">Train to Malmö</span></div>
+            <div class="calendar-day"><strong>8</strong><span class="day-label conf">Workshops / tutorials</span></div>
+            <div class="calendar-day"><strong>9</strong><span class="day-label conf">Workshops / tutorials</span></div>
+            <div class="calendar-day"><strong>10</strong><span class="day-label conf">Main conference</span></div>
+            <div class="calendar-day"><strong>11</strong><span class="day-label conf">Main conference</span></div>
+            <div class="calendar-day"><strong>12</strong><span class="day-label conf">Main conference</span></div>
+            <div class="calendar-day"><strong>13</strong><span class="day-label travel">Malmö → Billund</span><span class="day-label lego">LEGOLAND · partial</span></div>
+            <div class="calendar-day"><strong>14</strong><span class="day-label lego">LEGO House · 10–16</span></div>
+            <div class="calendar-day"><strong>15</strong><span class="day-label travel">Billund → Copenhagen</span></div>
+            <div class="calendar-day"><strong>16</strong><span class="day-label travel">SK935 nonstop home</span></div>
+            <div class="calendar-day"><strong>17</strong></div>
+            <div class="calendar-day"><strong>18</strong></div>
+            <div class="calendar-day"><strong>19</strong></div>
+            <div class="calendar-day"><strong>20</strong></div>
+            <div class="calendar-day"><strong>21</strong></div>
+            <div class="calendar-day"><strong>22</strong></div>
+            <div class="calendar-day"><strong>23</strong></div>
+            <div class="calendar-day"><strong>24</strong></div>
+            <div class="calendar-day"><strong>25</strong></div>
+            <div class="calendar-day"><strong>26</strong></div>
+            <div class="calendar-day"><strong>27</strong></div>
+            <div class="calendar-day"><strong>28</strong></div>
+            <div class="calendar-day"><strong>29</strong></div>
+            <div class="calendar-day"><strong>30</strong></div>
+            <div class="calendar-day empty"></div><div class="calendar-day empty"></div><div class="calendar-day empty"></div><div class="calendar-day empty"></div>
+          </div>
+        </div>
+      </div>
+    </section><section id="map" class="map-section">
+      <div class="wrap">
+        <div class="section-head">
+          <div>
+            <p class="eyebrow">The Nordic corridor</p>
+            <h2>Fly north first, then work south and west.</h2>
+          </div>
+          <p>The route avoids a connection on the way home: CPH to Stockholm by air, Stockholm to Malmö by rail, then Malmö to Billund and Copenhagen overland.</p>
+        </div>
+
+        <div class="map-shell">
+          <div class="map-stage">
+            <svg id="nordicMap" role="img" aria-labelledby="mapTitle mapDescription" viewBox="0 0 894 620">
+              <title id="mapTitle">Southern Nordic map of the ECCV family trip</title>
+              <desc id="mapDescription">A map highlighting Billund, Copenhagen Airport, Malmö and Hyllie, Lund, and the train route to Stockholm.</desc>
+            <g><g><path class="map-country" d="M1216.915,-906.105L1141.341,-855.603L1105.551,-843.931L1124.245,-932.715L1067.365,-984.234L998.501,-940.079L976.612,-847.384L934.272,-792.865L886.658,-822.662L828.82,-816.463L779.449,-882.158L752.766,-849.112L725.285,-844.147L718.734,-763.6L635.171,-782.935L623.348,-716.057L580.688,-716.469L551.449,-633.541L507.031,-508.772L438.168,-358.255L454.305,-322.838L438.807,-282.396L394.869,-284.158L366.109,-190.56L368.825,-63.006L397.106,-15.772L382.406,90.873L345.498,151.348L326.005,201.236L296.127,148.012L208.57,247.367L149.293,267.109L87.94,224.095L72.122,131.124L58.062,-79.033L98.964,-140.53L156.679,-181.883L216.08,-222.625L303.797,-327.129L384.963,-474.427L436.225,-581.824L491.693,-692.49L565.989,-782.513L625.188,-860.404L687.897,-939.185L785.361,-996.07L858.378,-989.008L925.963,-1099.782L1006.81,-1093.862L1086.538,-1121.204L1157.237,-1072.143L1225.383,-1022.202L1168.183,-986.961ZM508.629,-2662.832L525.406,-2748.949L590.594,-2757.855L646.516,-2669.72L722.136,-2579.898L792.71,-2491.096L735.902,-2446.43L681.027,-2401.338L656.262,-2241.571L617.436,-2202.398L596.346,-2035.761L542.821,-2028.342L447.275,-2149.303L487.539,-2222.636L421.072,-2283.571L379.413,-2375.981L334.633,-2471.057L300.122,-2657.677L359.544,-2702.963L421.072,-2747.616L445.358,-2659.394ZM1052.985,-2759.193L987.157,-2624.424L922.411,-2610.863L858.378,-2595.778L793.463,-2616.793L727.522,-2636.312L719.533,-2704.876L655.942,-2709.25L607.37,-2827.477L674.919,-2865.543L744.458,-2902.331L808.848,-2838.038L853.745,-2918.42L910.56,-2885.076L965.907,-2850.954ZM933.792,-2247.425L834.731,-2162.387L756.441,-2210.33L786.958,-2264.698L760.276,-2333.444L852.147,-2377.354L869.722,-2295.484Z"></path><path class="map-country is-focus" d="M326.005,201.236L345.498,151.348L382.406,90.873L397.106,-15.772L368.825,-63.006L366.109,-190.56L394.869,-284.158L438.807,-282.396L454.305,-322.838L438.168,-358.255L507.031,-508.772L551.449,-633.541L580.688,-716.469L623.348,-716.057L635.171,-782.935L718.734,-763.6L725.285,-844.147L752.766,-849.112L812.043,-788.846L881.226,-707.221L882.504,-531.2L897.363,-488.228L820.991,-457.505L778.011,-383.333L784.881,-319.624L714.42,-238.187L628.621,-153.629L596.346,-20.268L627.982,44.253L670.322,94.12L629.579,192.73L583.404,212.836L566.468,353.031L541.383,428.442L487.539,420.831L462.294,483.363L411.006,487.026L396.786,412.23L359.718,320.13Z"></path><path class="map-country" d="M709.148,559.261L763.791,567.859L845.436,566.67L868.124,574.853L878.829,598.098L880.747,631.288L893.049,659.517L892.73,688.896L866.207,703.738L879.788,737.353L880.747,769.382L902.956,831.049L898.322,850.704L876.273,858.799L836.01,916.103L847.354,946.683L837.767,942.685L795.586,916.578L763.631,926.17L742.701,919.186L716.338,933.73L693.969,909.573L675.755,918.83L673.198,914.798L652.907,880.929L619.833,876.731L615.679,855.056L585.162,847.315L578.611,865.189L554.485,850.825L557.201,831.657L524.127,825.568L503.037,802.817L484.823,757.455L488.338,732.59L477.313,693.724L461.176,667.591L473.478,647.817L463.253,609.852L493.45,587.745L562.793,552.63L618.715,526.635L662.972,539.593L666.328,558.201Z"></path><path class="map-country" d="M845.436,566.67L841.761,547.182L846.555,526.233L826.902,513.891L780.408,500.421L770.981,434.24L821.79,409.867L896.245,415.007L939.864,407.085L946.095,423.739L969.742,428.856L1012.402,467.167L1016.556,502.175L980.127,526.902L969.902,570.105L921.649,598.622L878.829,598.098L868.124,574.853Z"></path><path class="map-country" d="M1047.553,317.408L1068.963,336.412L1072.797,375.893L1087.017,423.324L1039.404,453.901L1012.402,467.167L969.742,428.856L946.095,423.739L939.864,407.085L896.245,415.007L821.79,409.867L770.981,434.24L772.579,373.924L794.308,322.564L836.169,294.387L871.48,355.863L907.11,354.306L915.578,291.063L953.445,276.278L972.778,286.432L1010.964,317.265Z"></path><path class="map-country" d="M1078.389,147.557L1078.389,147.557L1085.1,162.691L1053.464,212.391L1066.726,291.063L1047.553,317.408L1010.964,317.265L972.778,286.432L953.445,276.278L915.578,291.063L920.691,241.493L904.394,252.059L876.273,222.024L872.438,172.638L928.52,148.315L984.441,135.698L1032.534,150.135L1078.389,147.557Z"></path><path class="map-country" d="M167.987,1040.574L173.579,993.373L195.948,947.271L132.038,934.791L111.107,916.933L113.664,886.917L104.716,871.325L109.829,824.227L102.319,749.729L129.002,749.729L140.186,722.54L151.211,655.536L143.062,630.381L151.69,614.542L188.758,610.504L197.066,627.012L227.104,589.976L217.038,561.512L214.961,518.055L248.514,528.241L276.954,516.444L277.593,546.118L322.49,564.026L322.011,590.894L367.228,576.698L392.153,555.814L442.162,585.906L463.253,609.852L473.478,647.817L461.176,667.591L477.313,693.724L488.338,732.59L484.823,757.455L503.037,802.817L483.225,810.173L471.561,802.08L460.377,815.558L428.422,829.101L411.965,846.589L379.69,861.694L387.519,882.247L392.312,911.237L414.841,927.707L439.926,956.776L424.268,987.804L408.29,996.27L414.681,1039.43L410.527,1050.621L396.626,1037.142L375.376,1035.081L343.581,1046.971L304.436,1044.117L298.204,1061.434L275.676,1043.203L262.415,1046.857L214.802,1026.711L205.694,1041.031Z"></path><path class="map-country is-focus" d="M276.954,516.444L248.514,528.241L214.961,518.055L196.907,474.799L195.628,393.557L202.978,371.813L215.76,347.36L254.745,342.246L270.403,319.557L306.033,296.264L304.595,338.69L291.494,365.33L296.766,387.96L320.893,400.119L310.028,430.238L296.766,421.663L264.811,478.609ZM385.602,427.889L399.662,467.576L373.139,530.514L326.645,486.755L320.413,454.176Z"></path><path class="map-country" d="M1105.551,-843.931L1099,-758.369L1166.905,-679.461L1126.003,-592.503L1177.61,-466.517L1147.732,-375.131L1187.676,-298.114L1169.621,-232.471L1235.289,-165.097L1218.513,-115.84L1177.291,-61.05L1082.384,56.33L1082.384,56.33L1082.384,56.33L1001.857,63.521L923.726,96.282L851.508,114.906L825.784,66.33L782.804,36.699L792.71,-54.05L771.141,-139.86L792.391,-196.534L832.654,-259.07L934.112,-370.221L963.67,-392.292L959.197,-437.148L897.363,-488.228L882.504,-531.2L881.226,-707.221L812.043,-788.846L752.766,-849.112L779.449,-882.158L828.82,-816.463L886.658,-822.662L934.272,-792.865L976.612,-847.384L998.501,-940.079L1067.365,-984.234L1124.245,-932.715Z"></path></g><path class="map-route-core" d="M412.447,471.247L326.956,463.562L241.103,458.246L319.66,461.59L397.997,466.927"></path><path class="map-route-stockholm" d="M638.448,160.28L577.47,239.415L519.624,317.657L464.686,394.948L412.447,471.247"></path><path class="map-route-flight" d="M397.997,466.927L451.699,385.028L508.393,301.893L568.332,217.557L631.79,132.078"></path><g><g class="map-location" transform="translate(241.1027910098316,458.2464342147464)"><line class="map-leader" x2="-18" y2="-24"></line><circle class="map-marker-halo" r="9"></circle><circle class="map-marker-core" r="4.5"></circle><text class="map-label" x="-23" y="-24" text-anchor="end"><tspan x="-23">Billund</tspan><tspan class="map-label-note" x="-23" dy="14">2 nights · LEGO finish</tspan></text></g><g class="map-location" transform="translate(397.9965474945027,466.9274139160475)"><line class="map-leader" x2="-62" y2="33"></line><circle class="map-marker-halo" r="9"></circle><circle class="map-marker-core" r="4.5"></circle><text class="map-label" x="-67" y="33" text-anchor="end"><tspan x="-67">Copenhagen / CPH</tspan><tspan class="map-label-note" x="-67" dy="14">final night + SK935</tspan></text></g><g class="map-location" transform="translate(412.447229826377,471.24697490668586)"><line class="map-leader" x2="54" y2="28"></line><circle class="map-marker-halo" r="9"></circle><circle class="map-marker-core" r="4.5"></circle><text class="map-label" x="59" y="28" text-anchor="start"><tspan x="59">Malmö / Hyllie</tspan><tspan class="map-label-note" x="59" dy="14">Radisson + ECCV</tspan></text></g><g class="map-location" transform="translate(421.79401637150204,460.1137693956457)"><line class="map-leader" x2="50" y2="-30"></line><circle class="map-marker-halo" r="9"></circle><circle class="map-marker-core" r="4.5"></circle><text class="map-label" x="55" y="-30" text-anchor="start"><tspan x="55">Lund</tspan><tspan class="map-label-note" x="55" dy="14">easy family day</tspan></text></g><g class="map-location is-stockholm" transform="translate(638.4477352636325,160.28024557227445)"><line class="map-leader" x2="18" y2="-24"></line><circle class="map-marker-halo" r="9"></circle><circle class="map-marker-core" r="4.5"></circle><text class="map-label" x="23" y="-24" text-anchor="start"><tspan x="23">Stockholm</tspan><tspan class="map-label-note" x="23" dy="14">first 3 nights</tspan></text></g></g></g></svg>
+          </div>
+          <aside class="map-panel" aria-label="Map legend and route notes">
+            <div>
+              <h3>Three travel zones</h3>
+              <p>Stockholm is the arrival chapter, Malmö–Lund is the conference corridor, and Billund is the family finish before a protected Copenhagen departure night.</p>
+              <div class="map-legend">
+                <div class="map-key"><span class="map-key-line flight"></span><span>Air · CPH to Stockholm</span></div>
+                <div class="map-key"><span class="map-key-line stockholm"></span><span>Rail · Stockholm to Malmö</span></div>
+                <div class="map-key"><span class="map-key-line"></span><span>Ground · Malmö to Billund to CPH</span></div>
+                <div class="map-key"><span class="map-key-dot"></span><span>Trip location</span></div>
+              </div>
+            </div>
+            <div class="map-corridor">
+              <strong>Conference corridor</strong>
+              <p>CPH Airport → Hyllie → Triangeln → Malmö C → Lund runs on one rail axis; Hyllie is the conference stop.</p>
+            </div>
+          </aside>
+        </div>
+      </div>
+    </section><section id="bookings" class="section-white">
+      <div class="wrap">
+        <div class="section-head">
+          <div>
+            <p class="eyebrow">Completed bookings</p>
+            <h2>Confirmed travel and booked-cost ledger.</h2>
+          </div>
+          <p>This follows the Asia-trip format: operational confirmation details first, followed by a cost table that can grow as hotels, rail, transfers, and tickets are booked.</p>
+        </div>
+
+        <div class="booking-summary" aria-label="Booked cost summary">
+          <article class="booking-summary-card">
+            <span>Total booked</span>
+            <strong>≈$8.9k</strong>
+            <p>Confirmed airfare plus the six-night Malmö stay.</p>
+          </article>
+          <article class="booking-summary-card">
+            <span>Flights</span>
+            <strong>≈$6.1k</strong>
+            <p>Family of four, round trip, including taxes.</p>
+          </article>
+          <article class="booking-summary-card">
+            <span>Malmö hotel</span>
+            <strong>≈$2.8k</strong>
+            <p>Home Hotel Baltzar · Junior Suite · six nights.</p>
+          </article>
+          <article class="booking-summary-card">
+            <span>Free-cancel deadline</span>
+            <strong>Sep 5</strong>
+            <p>11:59pm Malmö time; after that, the stated penalty begins at one night plus taxes and fees.</p>
+          </article>
+        </div>
+
+        <div class="booking-ledger">
+          <article class="booking-group">
+            <div class="booking-group-head">
+              <div>
+                <h3>SAS · San Francisco to Stockholm / Copenhagen to San Francisco</h3>
+                <p>Family of four · SAS Light · confirmed itinerary</p>
+              </div>
+              <span class="booking-reference">Confirmed · details redacted</span>
+            </div>
+
+            <div class="flight-booking-grid" aria-label="Confirmed SAS flight segments">
+              <div class="flight-leg">
+                <div class="flight-date">Thu–Fri · Sep 3–4</div>
+                <h4>SK936 · SFO → CPH</h4>
+                <p>16:45 Terminal I → 12:00 Terminal 3 (+1 day)</p>
+                <p>10h 15m · Airbus A350-900</p>
+                <p>Assigned seats · meal included</p>
+              </div>
+              <div class="flight-leg">
+                <div class="flight-date">Fri · Sep 4</div>
+                <h4>SK1426 · CPH → ARN</h4>
+                <p>13:50 Terminal 3 → 15:05 Terminal 5</p>
+                <p>1h 15m · Airbus A320neo</p>
+                <p>Assigned seats · 1h 50m protected connection</p>
+              </div>
+              <div class="flight-leg">
+                <div class="flight-date">Wed · Sep 16</div>
+                <h4>SK935 · CPH → SFO</h4>
+                <p>12:45 Terminal 3 → 14:40 Terminal I</p>
+                <p>10h 55m nonstop · Airbus A350-900</p>
+                <p>Assigned seats · meal included</p>
+              </div>
+            </div>
+
+            <ul class="booking-detail-list">
+              <li><strong>Travelers</strong>Two adults and two young children</li>
+              <li><strong>Outbound itinerary</strong>SFO → CPH → ARN · 13h 20m total · one protected connection</li>
+              <li><strong>Return itinerary</strong>CPH → SFO · 10h 55m · nonstop</li>
+              <li><strong>Ticket conditions</strong>SAS Light; review baggage, cancellation, and rebooking rules before travel</li>
+            </ul>
+
+            <p class="decision-note"><strong>Public-edition note:</strong> passenger names, reservation identifiers, assigned seats, loyalty details, contact information, and payment data are not included. Review the <a href="https://www.flysas.com/en/fly-with-us/ticket-options/ticket-types/" target="_blank" rel="noreferrer">SAS ticket-type rules</a> for the general Light-fare conditions.</p>
+          </article>
+
+          <article class="booking-group">
+            <div class="booking-group-head">
+              <div>
+                <h3>Home Hotel Baltzar · Malmö</h3>
+                <p>Junior Suite · confirmed for a family of four</p>
+              </div>
+              <span class="booking-reference">Confirmed · 6 nights</span>
+            </div>
+
+            <div class="flight-booking-grid" aria-label="Confirmed Home Hotel Baltzar stay">
+              <div class="flight-leg">
+                <div class="flight-date">Check-in · Mon, Sep 7</div>
+                <h4>3:00pm</h4>
+                <p>Arrive from Stockholm after the direct train to Malmö Central.</p>
+              </div>
+              <div class="flight-leg">
+                <div class="flight-date">Room · Sep 7–13</div>
+                <h4>Junior Suite</h4>
+                <p>Non-smoking · 1 room · family of four · maximum occupancy 4</p>
+              </div>
+              <div class="flight-leg">
+                <div class="flight-date">Check-out · Sun, Sep 13</div>
+                <h4>11:00am</h4>
+                <p>Leave for Billund after the full ECCV week and Saturday night in Malmö.</p>
+              </div>
+            </div>
+
+            <ul class="booking-detail-list">
+              <li><strong>Address</strong>Baltzarsgatan 45, Malmö, 211 36 Sweden</li>
+              <li><strong>Station approach</strong>About ten minutes on foot to Malmö Central</li>
+              <li><strong>Free cancellation</strong>Until September 5 at 11:59pm, property local time</li>
+              <li><strong>Late arrival</strong>Contact the hotel in advance if arrival will be after 10:00pm</li>
+              <li><strong>Meals</strong>Home Hotel's breakfast, afternoon fika, and dinner simplify conference-week logistics</li>
+              <li><strong>Booking record</strong>Reservation and payment identifiers retained only in the private master</li>
+            </ul>
+
+            <p class="decision-note"><strong>Operational check:</strong> the Junior Suite is confirmed for four guests. Before the free-cancellation deadline, ask the hotel to confirm that the sofa bed will be prepared for both children and note any property-collected mandatory fees not shown in the prepaid total.</p>
+          </article>
+
+          <article class="booking-group">
+            <div class="booking-group-head">
+              <div>
+                <h3>Booked cost rollup</h3>
+                <p>USD ledger. Only confirmed, paid costs count toward the total.</p>
+              </div>
+              <span class="tag blue">Airfare booked</span>
+            </div>
+
+            <div class="cost-table-wrap">
+              <table class="cost-sheet" aria-label="Scandi ECCV booked cost rollup">
+                <thead>
+                  <tr>
+                    <th>Category</th>
+                    <th>Line item</th>
+                    <th>Unit detail</th>
+                    <th class="num">Approx. component</th>
+                    <th class="num">Approx. booked</th>
+                    <th>Status / notes</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr>
+                    <td>Airfare</td>
+                    <td>SAS base flights</td>
+                    <td>Family of four</td>
+                    <td class="num">≈$3.8k</td>
+                    <td class="num">≈$3.8k</td>
+                    <td>SK936, SK1426, and SK935 · SAS Light</td>
+                  </tr>
+                  <tr>
+                    <td>Airfare</td>
+                    <td>Taxes and carrier-imposed fees</td>
+                    <td>Family of four</td>
+                    <td class="num">≈$2.3k</td>
+                    <td class="num">≈$2.3k</td>
+                    <td>Included in paid total</td>
+                  </tr>
+                  <tr>
+                    <td>Airfare</td>
+                    <td>Seat assignments</td>
+                    <td>Seats assigned across all segments</td>
+                    <td class="num">$0</td>
+                    <td class="num">$0</td>
+                    <td>No added seat charge</td>
+                  </tr>
+                  <tr class="subtotal-row">
+                    <td colspan="4">Airfare subtotal · 4 passengers</td>
+                    <td class="num">≈$6.1k</td>
+                    <td>Approximately $1.5k per traveler</td>
+                  </tr>
+                  <tr>
+                    <td>Hotels</td>
+                    <td>Home Hotel Baltzar · room</td>
+                    <td>Junior Suite · 6 nights</td>
+                    <td class="num">≈$2.6k</td>
+                    <td class="num">≈$2.6k</td>
+                    <td>Confirmed; reservation identifier redacted</td>
+                  </tr>
+                  <tr>
+                    <td>Hotels</td>
+                    <td>Home Hotel Baltzar · extra guest</td>
+                    <td>2 children included in confirmed occupancy</td>
+                    <td class="num">≈$0.2k</td>
+                    <td class="num">≈$0.2k</td>
+                    <td>Added to room price</td>
+                  </tr>
+                  <tr>
+                    <td>Hotels</td>
+                    <td>Home Hotel Baltzar · taxes</td>
+                    <td>Prepaid taxes shown by Hotels.com</td>
+                    <td class="num">≈$0.3k</td>
+                    <td class="num">≈$0.3k</td>
+                    <td>Property may collect additional required fees/taxes</td>
+                  </tr>
+                  <tr>
+                    <td>Hotels</td>
+                    <td>Travel credit applied</td>
+                    <td>Credit against this reservation</td>
+                    <td class="num">≈-$0.3k</td>
+                    <td class="num">≈-$0.3k</td>
+                    <td>Account-specific rewards details redacted</td>
+                  </tr>
+                  <tr class="subtotal-row">
+                    <td colspan="4">Home Hotel Baltzar subtotal · 6 nights</td>
+                    <td class="num">≈$2.8k</td>
+                    <td>Approximately $470/night after applied credit</td>
+                  </tr>
+                  <tr>
+                    <td>Hotels</td>
+                    <td>Stockholm, Billund, Copenhagen</td>
+                    <td>6 remaining room nights planned</td>
+                    <td class="num">—</td>
+                    <td class="num">—</td>
+                    <td class="pending">Not yet booked</td>
+                  </tr>
+                  <tr>
+                    <td>Rail + ground</td>
+                    <td>Stockholm → Malmö → Billund → Copenhagen</td>
+                    <td>Family of four</td>
+                    <td class="num">—</td>
+                    <td class="num">—</td>
+                    <td class="pending">Not yet booked</td>
+                  </tr>
+                  <tr>
+                    <td>Conference + activities</td>
+                    <td>ECCV, LEGOLAND, LEGO House, Stockholm sights</td>
+                    <td>Registration and family tickets</td>
+                    <td class="num">—</td>
+                    <td class="num">—</td>
+                    <td class="pending">Not yet rolled in</td>
+                  </tr>
+                  <tr class="total-row">
+                    <td colspan="4">Grand total · confirmed booked costs</td>
+                    <td class="num">≈$8.9k</td>
+                    <td>Flights + Malmö hotel; add remaining confirmations here as they are booked.</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
+          </article>
+        </div>
+      </div>
+    </section><section id="stockholm">
+      <div class="wrap">
+        <div class="section-head">
+          <div>
+            <p class="eyebrow">Next decision · Stockholm · Sep 4–7</p>
+            <h2>Optimize the first 18 hours, not the prettiest address.</h2>
+          </div>
+          <p>This is the family's first Stockholm visit, but the Friday arrival follows a 13-hour, 20-minute itinerary and a nine-hour time change. A true four-person room beside Stockholm Central is more valuable than Gamla Stan atmosphere or an outlying apartment.</p>
+        </div>
+
+        <div class="active-decision">
+          <div>
+            <span class="tag yellow">Book next · refundable</span>
+            <h3>First hold: Scandic Continental · Superior Family</h3>
+            <p>It is effectively at Stockholm Central, so the Arlanda Express arrival and Monday train departure require almost no extra logistics. The 27–34 m² Superior Family category officially sleeps four and includes a bunk bed, blackout curtains, and air cooling—the most useful combination for jet-lagged children.</p>
+          </div>
+          <ul class="decision-action-list">
+            <li><strong>Dates</strong>September 4–7 · three nights</li>
+            <li><strong>Room wording</strong>Superior Family · maximum four guests</li>
+            <li><strong>Rate</strong>Prefer free cancellation; do not book a generic Superior</li>
+            <li><strong>Ask</strong>Early bag drop, exact bunk setup, and a quiet exterior-facing room</li>
+            <li><strong>Airport rail</strong>Arlanda Express: 18 minutes; current two-adult group fare SEK 460, children 0–17 free with adults</li>
+          </ul>
+        </div>
+
+        <div class="stockholm-stay-grid" aria-label="Stockholm family hotel shortlist">
+          <article class="stockholm-stay-card is-first">
+            <span class="tag blue">01 · Best overall</span>
+            <h3>Scandic Continental</h3>
+            <div class="hotel-location">Vasagatan 22 · Stockholm Central: 0 km</div>
+            <p>The Superior Family is 27–34 m² for four, with a bunk bed, blackout curtains, air cooling, and kettle. Weekend breakfast begins at 07:00—helpful, though the children may still wake earlier.</p>
+            <div class="amenities"><span class="amenity">True bunk bed</span><span class="amenity">Blackout</span><span class="amenity">At Central</span><span class="amenity">Breakfast 07:00</span></div>
+            <a class="hotel-link" href="https://www.scandichotels.com/en/hotels/scandic-continental" target="_blank" rel="noreferrer">Official hotel</a>
+          </article>
+
+          <article class="stockholm-stay-card">
+            <span class="tag yellow">02 · Quiet/design backup</span>
+            <h3>Nordic Light Hotel</h3>
+            <div class="hotel-location">Vasaplan 7 · beside the Arlanda Express side of Central</div>
+            <p>The Deluxe King is 28–35 m² and officially allows one to four guests, with strongly soundproofed windows. Confirm the exact extra-bed or sofa-bed configuration before paying; the official room summary does not spell it out.</p>
+            <div class="amenities"><span class="amenity">28–35 m²</span><span class="amenity">Max 4</span><span class="amenity">Soundproofed</span><span class="amenity">Minibar</span></div>
+            <a class="hotel-link" href="https://nordiclighthotel.com/rooms-and-suites/" target="_blank" rel="noreferrer">Official rooms</a>
+          </article>
+
+          <article class="stockholm-stay-card">
+            <span class="tag">03 · Strong station backup</span>
+            <h3>Radisson Blu Royal Viking</h3>
+            <div class="hotel-location">Vasagatan 1 · about 150 m from Central</div>
+            <p>The Family Room is 28 m² and rated for four adults, with luggage storage and a direct station-side arrival. Verify the actual children's beds. Its pool was scheduled for renovation through late summer 2026, so assign it no pool value unless reopening is confirmed.</p>
+            <div class="amenities"><span class="amenity">28 m²</span><span class="amenity">Max 4</span><span class="amenity">150 m walk</span><span class="amenity">Bag storage</span></div>
+            <a class="hotel-link" href="https://www.radissonhotels.com/en-us/hotels/radisson-blu-stockholm-royal-viking" target="_blank" rel="noreferrer">Official hotel</a>
+          </article>
+        </div>
+
+        <p class="decision-note"><strong>Apartment verdict:</strong> for only three nights, with jet lag on arrival and a long-distance train on departure, a kitchen and laundry are not worth adding a metro ride. Choose an apartment only if it provides genuinely separate sleeping space at a compelling rate; otherwise stay at Central.</p>
+
+        <div class="shortlist-callout">
+          <div>
+            <h3>Stockholm Central → Malmö Central: about 4½ hours direct</h3>
+            <p>For Monday, September 7, SJ currently shows direct X 2000 trips in 4h31–4h33. A live family search for two adults and two young children, with SJ’s Family offer applied, showed early direct totals of SEK 2,196 at 05:22, SEK 2,380 at 06:20, and SEK 2,978 at 07:22. Prices are dynamic, so use SEK 2,200–3,500 as the working family budget and book a direct train once the preferred departure is clear.</p>
+          </div>
+          <ul class="micro-list">
+            <li>Route: city center to city center</li>
+            <li>Direct X 2000: ≈4h31–4h33</li>
+            <li>Family quote checked: Aug 9, 2026</li>
+            <li>Cheaper 1-change example: SEK 1,804, but 6h52</li>
+          </ul>
+        </div>
+
+        <div class="jetlag-note">
+          <h3>The arrival rule: daylight, food, bed—nothing ticketed.</h3>
+          <p>At 15:05 in Stockholm the family's body clock is around 06:05 in California. Use the 18-minute Arlanda Express, aim to be in the room around 16:30, spend 30–45 minutes outside, eat around 17:30, and let bedtime happen between 19:30 and 20:30. Skip a late nap and do not make the first evening depend on Gamla Stan cobbles or a restaurant reservation.</p>
+        </div>
+
+        <div class="mini-steps" aria-label="Jet-lag-aware Stockholm three-night itinerary">
+          <article class="mini-step"><strong>Friday, Sep 4 · land softly</strong><span>ARN 15:05 → Arlanda Express → Central hotel. After check-in, use the City Hall waterfront or a short Norrmalm loop for daylight, eat close to the hotel, then go to bed early.</span></article>
+          <article class="mini-step"><strong>Saturday, Sep 5 · one guaranteed win</strong><span>Expect a very early wake-up; carry room snacks because weekend breakfast may not begin until 07:00. Put Vasa first at opening, eat on Djurgården, and add Junibacken only if the children still have energy. Ferry back and keep dinner unreserved.</span></article>
+          <article class="mini-step"><strong>Sunday, Sep 6 · decide at breakfast</strong><span>If everyone slept and the weather is good, make Skansen the single anchor. If energy is mixed, choose Gamla Stan, the Royal Palace exterior, and a short Djurgården ferry instead. A long archipelago cruise is a poor use of the only flexible day.</span></article>
+          <article class="mini-step"><strong>Monday, Sep 7 · protect the transfer</strong><span>Breakfast, check out, and take a direct X 2000 from Stockholm Central to Malmö Central in about 4½ hours. A mid-morning departure is the nicest rhythm if the live fare is reasonable.</span></article>
+        </div>
+
+        <div class="destination-grid" style="margin-top:22px">
+          <article class="destination-card stockholm">
+            <div class="stamp">Sep 4–7 · 3 nights</div>
+            <span class="tag yellow">The essential</span>
+            <h3>Vasa + Djurgården</h3>
+            <p>The 17th-century Vasa is the city’s signature family sight: dramatically intact, indoors, and free for visitors 18 and under. The museum has a family trail and a film for younger visitors.</p>
+            <div class="destination-verdict"><strong>Bookend it with Junibacken.</strong><span>The Story Train and children’s-literature spaces suit ages 5 and 7; it is open that weekend but closed Monday.</span></div>
+          </article>
+          <article class="destination-card">
+            <span class="tag blue">Full family day</span>
+            <h3>Skansen</h3>
+            <p>Open-air historic Sweden, Nordic animals, playgrounds, and demonstrations make it the broadest all-ages choice. It can easily consume most of Sunday.</p>
+            <div class="destination-verdict"><strong>Choose it, do not add it.</strong><span>If Skansen wins, save City Hall and a longer archipelago outing for another trip.</span></div>
+          </article>
+          <article class="destination-card">
+            <span class="tag">Flexible alternative</span>
+            <h3>Old Town + water</h3>
+            <p>Gamla Stan, the Royal Palace exterior, a city ferry, and Östermalm Market Hall provide the classic Stockholm texture without committing to another large museum.</p>
+            <div class="destination-verdict"><strong>Best mixed-energy Sunday.</strong><span>Keep the boat short in September and treat the market hall as a tasting stop, not a formal event.</span></div>
+          </article>
+        </div>
+
+        <div class="program-watch">
+          <div>
+            <p class="eyebrow">Eat like Stockholm</p>
+            <h3>Six things to order</h3>
+            <p>For one classic dinner, Tradition in Gamla Stan is an easy first-timer candidate. For flexible sampling, use Östermalm Market Hall; for fika, follow the nearest good bakery rather than crossing town.</p>
+          </div>
+          <div class="watch-grid">
+            <div class="watch-topic"><strong>Swedish meatballs</strong><span>With mashed potatoes, cream gravy, lingonberries, and pickled cucumber—the familiar family win.</span></div>
+            <div class="watch-topic"><strong>Toast Skagen</strong><span>Prawns, mayonnaise, dill, lemon, and roe on toast; a Stockholm classic for the adults to share.</span></div>
+            <div class="watch-topic"><strong>Herring or gravlax</strong><span>Try pickled or fried herring, or cured salmon, without committing the children to a full plate.</span></div>
+            <div class="watch-topic"><strong>Fika buns</strong><span>Kanelbulle for cinnamon; kardemummabulle for cardamom. The pause and coffee matter as much as the pastry.</span></div>
+            <div class="watch-topic"><strong>Princess cake</strong><span>Green marzipan, cream, and sponge. Prinsesstårta is a Stockholm-born celebration cake worth sharing.</span></div>
+            <div class="watch-topic"><strong>Swedish pancakes</strong><span>Thin pancakes with jam and cream: useful insurance when the children are less interested in herring.</span></div>
+          </div>
+        </div>
+      </div>
+    </section><section id="base" class="section-blue">
+      <div class="wrap">
+        <div class="section-head">
+          <div>
+            <p class="eyebrow">The one-seat test</p>
+            <h2>Home Hotel Baltzar is booked—and the commute still works.</h2>
+          </div>
+          <p>The Junior Suite gives the family a central old-town base, included meals, and a one-seat rail commute. The tradeoff is a roughly ten-minute walk to Malmö Central.</p>
+        </div>
+
+        <div class="commute-check">
+          <div>
+            <span class="tag yellow">Booked · Sep 7–13</span>
+            <h3>Baltzar → ECCV in about 22–28 minutes</h3>
+            <p>That estimate includes the ten-minute walk to Malmö Central, a normal platform wait, the direct train to Hyllie, and the short venue walk.</p>
+          </div>
+          <div class="commute-strip" aria-label="Home Hotel Baltzar to ECCV commute">
+            <div class="commute-leg"><strong>Home Hotel Baltzar</strong><span>Booked Junior Suite; breakfast, fika, and dinner included</span></div>
+            <div class="commute-leg"><strong>≈10 min walk</strong><span>Hotel to Malmö Central station</span></div>
+            <div class="commute-leg"><strong>≈7 min train</strong><span>Direct Malmö C → Hyllie; no transfer</span></div>
+            <div class="commute-leg"><strong>2–4 min walk</strong><span>Hyllie platform → Arena or Malmömässan</span></div>
+          </div>
+        </div>
+
+        <div class="border-warning"><strong>Only remaining Baltzar check:</strong> before September 5 at 11:59pm, confirm that the Junior Suite's sofa bed will be prepared for both children and ask whether any mandatory property-collected fees remain.</div>
+
+        <div class="rail-board">
+          <aside class="rail-spine" aria-label="Direct train stations to Hyllie">
+            <h3>The conference line</h3>
+            <p>Approximate scheduled train times to Hyllie; hotel door-to-door time will be longer.</p>
+            <div class="station-list">
+              <div class="station">
+                <span class="station-dot" aria-hidden="true"></span>
+                <div><strong>Lund C</strong><span>Sweden · direct regional train</span></div>
+                <div class="station-time">≈21 min</div>
+              </div>
+              <div class="station">
+                <span class="station-dot" aria-hidden="true"></span>
+                <div><strong>Malmö C</strong><span>Old town + main rail hub</span></div>
+                <div class="station-time">≈7 min</div>
+              </div>
+              <div class="station">
+                <span class="station-dot" aria-hidden="true"></span>
+                <div><strong>Triangeln</strong><span>Best family-city balance</span></div>
+                <div class="station-time">≈4 min</div>
+              </div>
+              <div class="station is-venue">
+                <span class="station-dot" aria-hidden="true"></span>
+                <div><strong>Hyllie</strong><span>Malmö Arena + Malmömässan</span></div>
+                <div class="station-time">Venue</div>
+              </div>
+              <div class="station">
+                <span class="station-dot" aria-hidden="true"></span>
+                <div><strong>CPH Airport</strong><span>Denmark · border crossing</span></div>
+                <div class="station-time">≈14 min</div>
+              </div>
+              <div class="station">
+                <span class="station-dot" aria-hidden="true"></span>
+                <div><strong>Ørestad</strong><span>Denmark · apartments + Field's</span></div>
+                <div class="station-time">≈21 min</div>
+              </div>
+            </div>
+          </aside>
+
+          <div>
+            <div class="base-list">
+              <article class="base-row">
+                <div class="base-rank">1</div>
+                <h3>Triangeln, Malmö</h3>
+                <p>The shortest family-city commute: one stop, lively but family-usable, close to parks and food, with strong apartment-hotel options.</p>
+                <div class="base-commute"><strong>4 min</strong><span>train only</span></div>
+              </article>
+              <article class="base-row">
+                <div class="base-rank">2</div>
+                <h3>Malmö Central</h3>
+                <p>Best for Stockholm arrival, Billund logistics, and old-town evenings. Baltzar is now the confirmed base, about ten minutes on foot from the station.</p>
+                <div class="base-commute"><strong>7 min</strong><span>train only</span></div>
+              </article>
+              <article class="base-row">
+                <div class="base-rank">3</div>
+                <h3>Lund Central</h3>
+                <p>A charming family base with a direct train. Worth it only if the room is substantially better and truly close to Lund C.</p>
+                <div class="base-commute"><strong>21 min</strong><span>train only</span></div>
+              </article>
+              <article class="base-row">
+                <div class="base-rank">4</div>
+                <h3>Ørestad</h3>
+                <p>Useful fallback for apartment inventory and airport access, but the daily international commute means ID checks, two currencies, and higher friction.</p>
+                <div class="base-commute"><strong>21 min</strong><span>train only</span></div>
+              </article>
+              <article class="base-row">
+                <div class="base-rank">5</div>
+                <h3>CPH Airport / Kastrup</h3>
+                <p>Fastest Danish fallback and excellent for the flight home, but weak as a weeklong family neighborhood. Use only for a major room or price advantage.</p>
+                <div class="base-commute"><strong>14 min</strong><span>train only</span></div>
+              </article>
+            </div>
+
+            <div class="border-warning"><strong>Before September 5 at 11:59pm:</strong> confirm that the Junior Suite's sofa bed will be prepared for both children and ask whether any mandatory property-collected fees remain. This is the free-cancellation deadline in Malmö local time.</div>
+          </div>
+        </div>
+      </div>
+    </section><section id="hotels" class="section-white">
+      <div class="wrap">
+        <div class="section-head">
+          <div>
+            <p class="eyebrow">Malmö hotel · decision complete</p>
+            <h2>Home Hotel Baltzar Junior Suite is booked.</h2>
+          </div>
+          <p>The selected stay is September 7–13 for two adults and two children. The other cards remain as an archived comparison until the September 5 free-cancellation deadline.</p>
+        </div>
+
+        <div class="filter-row" role="group" aria-label="Filter lodging shortlist">
+          <button class="filter-button" type="button" data-filter="all" aria-pressed="true">All</button>
+          <button class="filter-button" type="button" data-filter="triangeln" aria-pressed="false">Triangeln</button>
+          <button class="filter-button" type="button" data-filter="central" aria-pressed="false">Malmö C</button>
+          <button class="filter-button" type="button" data-filter="oldtown" aria-pressed="false">Old town</button>
+        </div>
+
+        <div class="hotel-grid">
+          <article class="hotel-card" data-area="central">
+            <div class="hotel-number">02</div>
+            <span class="tag">Space-first backup</span>
+            <h3>Radisson Blu Hotel Malmö</h3>
+            <div class="hotel-location">Caroli / Malmö C · official 600 m, 8-minute station walk</div>
+            <p>The Family Room sleeps the group and, like every room here, is at least 43 m²—far more livable than the 25 m² options for a six-night conference stay. The station walk is only a few minutes longer than Comfort's.</p>
+            <div class="amenities"><span class="amenity">43 m²</span><span class="amenity">Family occupancy</span><span class="amenity">Climate control</span><span class="amenity">Fridge / kettle</span></div>
+            <div class="hotel-bottom"><div><span>Door to ECCV</span><strong>≈20–26 min</strong></div><a class="hotel-link" href="https://www.radissonhotels.com/en-us/hotels/radisson-blu-malmo/rooms" target="_blank" rel="noreferrer">Official rooms</a></div>
+          </article>
+
+          <article class="hotel-card" data-area="central">
+            <div class="hotel-number">03</div>
+            <span class="tag yellow">Transit-first backup</span>
+            <h3>Comfort Hotel Malmö</h3>
+            <div class="hotel-location">Behind Malmö C · a few minutes to the platforms</div>
+            <p>The 25 m² Family Room has a double or twins plus an armchair bed; a fourth extra bed can be requested. It is the easiest commute of the four, but it will feel tight and routine cleaning is every fourth day.</p>
+            <div class="amenities"><span class="amenity">25 m²</span><span class="amenity">Shortest walk</span><span class="amenity">Climate control</span><span class="amenity">Breakfast rate-dependent</span></div>
+            <div class="hotel-bottom"><div><span>Door to ECCV</span><strong>≈15–21 min</strong></div><a class="hotel-link" href="https://www.strawberryhotels.com/hotels/sweden/malmo/comfort-hotel-malmo/" target="_blank" rel="noreferrer">Official rooms</a></div>
+          </article>
+
+          <article class="hotel-card" data-area="oldtown" data-booked="true">
+            <div class="hotel-number">01</div>
+            <span class="tag blue">Booked · Sep 7–13</span>
+            <h3>Home Hotel Baltzar</h3>
+            <div class="hotel-location">Old town / Malmö C · about 10 minutes to station</div>
+            <p>The confirmed non-smoking Junior Suite fits four and uses a double bed plus sofa bed. Breakfast, fika, and dinner remove real conference-week friction; confirm the sofa bed will be prepared for both children.</p>
+            <div class="amenities"><span class="amenity">Junior Suite</span><span class="amenity">Breakfast + fika + dinner</span><span class="amenity">Fridge</span><span class="amenity">Free cancel to Sep 5</span></div>
+            <div class="hotel-bottom"><div><span>Door to ECCV</span><strong>≈22–28 min</strong></div><a class="hotel-link" href="https://www.strawberryhotels.com/hotels/sweden/malmo/home-hotel-baltzar/" target="_blank" rel="noreferrer">Official rooms</a></div>
+          </article>
+
+          <article class="hotel-card" data-area="oldtown">
+            <div class="hotel-number">04</div>
+            <span class="tag">Best kid setup</span>
+            <h3>Best Western Plus Hotel Noble House</h3>
+            <div class="hotel-location">Lilla Torg / Malmö C · about 10 minutes to station</div>
+            <p>The family category uses two single beds plus a single bunk bed, breakfast is included, and there is a children's play corner. Only three themed family rooms exist, so the exact category matters more than the brand-level reservation.</p>
+            <div class="amenities"><span class="amenity">Real bunk layout</span><span class="amenity">Breakfast included</span><span class="amenity">Kids' corner</span><span class="amenity">Only 3 rooms</span></div>
+            <div class="hotel-bottom"><div><span>Door to ECCV</span><strong>≈22–28 min</strong></div><a class="hotel-link" href="https://www.bestwestern.se/hotell/best-western-plus-hotel-noble-house-88158" target="_blank" rel="noreferrer">Official rooms</a></div>
+          </article>
+
+          <article class="hotel-card" data-area="triangeln">
+            <div class="hotel-number">05</div>
+            <span class="tag">Recheck inventory</span>
+            <h3>Scandic Triangeln</h3>
+            <div class="hotel-location">Triangeln · at the station complex</div>
+            <p>The official Standard Family Four sleeps four in 23–25 m². It is the best pure commute—one four-minute train stop—and includes a bathtub and air cooling, but it is tighter than the booked Junior Suite.</p>
+            <div class="amenities"><span class="amenity">Sleeps 4</span><span class="amenity">At station</span><span class="amenity">Air cooling</span><span class="amenity">Breakfast</span></div>
+            <div class="hotel-bottom"><div><span>Door to ECCV</span><strong>≈8–13 min</strong></div><a class="hotel-link" href="https://www.scandichotels.com/en/hotels/scandic-triangeln" target="_blank" rel="noreferrer">Official rooms</a></div>
+          </article>
+
+          <article class="hotel-card" data-area="triangeln">
+            <div class="hotel-number">06</div>
+            <span class="tag">Apartment watchlist</span>
+            <h3>The More Hotel Mazetti</h3>
+            <div class="hotel-location">Triangeln · about 5 minutes to station</div>
+            <p>If a four-person unit reappears, this is the best format match: kitchenette in every room, free bookable laundry, and separate-bedroom categories, with a short one-stop commute to Hyllie.</p>
+            <div class="amenities"><span class="amenity">Sleeps 4</span><span class="amenity">Kitchenette</span><span class="amenity">Laundry</span><span class="amenity">Separate-room options</span></div>
+            <div class="hotel-bottom"><div><span>Door to ECCV</span><strong>≈12–18 min</strong></div><a class="hotel-link" href="https://www.themorehotel.se/en/mazetti/hotellrum-mazetti/" target="_blank" rel="noreferrer">Official rooms</a></div>
+          </article>
+        </div>
+
+        <div class="shortlist-callout">
+          <div>
+            <h3>Booked: Baltzar Junior Suite.</h3>
+            <p>The private booking record confirms six nights for four guests at approximately $2.8k after an applied travel credit. The included meal pattern and central location outweigh the modestly longer station walk.</p>
+          </div>
+          <ul class="micro-list">
+            <li>Check-in: Sep 7 at 3:00pm</li>
+            <li>Check-out: Sep 13 at 11:00am</li>
+            <li>Free cancel: Sep 5 at 11:59pm local</li>
+            <li>Confirm: sofa bed prepared + any property fees</li>
+          </ul>
+        </div>
+      </div>
+    </section><section id="conference" class="conference-plan">
+      <div class="wrap">
+        <div class="section-head">
+          <div>
+            <p class="eyebrow">ECCV attendance plan</p>
+            <h2>Build the week around agents, reasoning, world models, and evaluation.</h2>
+          </div>
+          <p>The workshop choices are concrete now. The main-conference program and poster sessions are not yet public, so September 10–12 stays flexible around your poster assignment and a focused paper watchlist.</p>
+        </div>
+
+        <article class="paper-status">
+          <div class="paper-status-main">
+            <span class="tag yellow">Author poster confirmed · details redacted</span>
+            <h3>Conference poster presentation</h3>
+            <p>The author notification confirms poster presentation format. The paper number and title are omitted from this public edition; the date, session, time, room, and board number remain unassigned.</p>
+          </div>
+          <div class="paper-status-side">
+            <strong>Exact presentation slot: TBA</strong>
+            <span>Protect all three main-conference days, September 10–12. The preferred route now keeps Saturday night in Malmö, so even a late poster slot no longer forces a same-evening transfer.</span>
+          </div>
+        </article>
+
+        <div class="conference-days">
+          <article class="conference-day">
+            <div class="conference-day-head">
+              <p class="eyebrow">Tuesday · September 8</p>
+              <h3>Primary: Multimodal Digital Agents</h3>
+            </div>
+            <div class="session-pick">
+              <div class="session-time">Full day</div>
+              <div>
+                <h4><a href="https://eccv.ecva.net/Conferences/2026/Workshops" target="_blank" rel="noreferrer">Multimodal Digital Agents Workshop</a></h4>
+                <p>The closest all-day match to your current work: vision-centric agents across web, desktop, and mobile. The announced speaker set includes Graham Neubig, Ranjay Krishna, Qianhui Wu, and Alexandre Drouin.</p>
+              </div>
+            </div>
+            <div class="session-pick">
+              <div class="session-time">Pivot</div>
+              <div>
+                <h4><a href="https://beamv2-eccv-workshop.github.io/" target="_blank" rel="noreferrer">BEAM 2 · Evidence-Aligned Multimodal Reasoning</a></h4>
+                <p>Directly relevant to self-verification and trustworthy evaluation. ECCV lists it as afternoon, while the workshop site currently says 09:00–13:00. Do not split the day until organizers reconcile that conflict.</p>
+              </div>
+            </div>
+            <div class="session-pick">
+              <div class="session-time">Backup</div>
+              <div>
+                <h4><a href="https://eccv.ecva.net/Conferences/2026/Tutorials" target="_blank" rel="noreferrer">From Perception to Simulation</a></h4>
+                <p>The afternoon tutorial on emerging world models in multimodal reasoning is the cleanest alternative if the agent workshop agenda ends up weak for your priorities.</p>
+              </div>
+            </div>
+          </article>
+
+          <article class="conference-day">
+            <div class="conference-day-head">
+              <p class="eyebrow">Wednesday · September 9</p>
+              <h3>Primary: World Models for Embodied AI</h3>
+            </div>
+            <div class="session-pick">
+              <div class="session-time">Full day</div>
+              <div>
+                <h4><a href="https://eccv26wmeai.github.io/" target="_blank" rel="noreferrer">How to Build Effective World Models for Embodied AI</a></h4>
+                <p>The strongest single-day fit for learned dynamics, simulation, and embodied agents. The announced roster spans autonomy, egocentric video, robotics, and representation learning; schedule details remain TBA.</p>
+              </div>
+            </div>
+            <div class="session-pick">
+              <div class="session-time">AM split</div>
+              <div>
+                <h4>Multimodal Reasoning and Slow Thinking</h4>
+                <p>Use this official morning workshop as the reasoning-first alternative if its final agenda lands closer to SVRL than the world-model program.</p>
+              </div>
+            </div>
+            <div class="session-pick">
+              <div class="session-time">PM split</div>
+              <div>
+                <h4>Wearables AI or Evaluating Visual Foundation Models</h4>
+                <p>Wearables AI matches real-time multimodal assistants; the evaluation tutorial matches your measurement and model-comparison interests. Choose only after detailed programs appear.</p>
+              </div>
+            </div>
+          </article>
+        </div>
+
+        <div class="program-watch">
+          <div>
+            <p class="eyebrow">September 10–12</p>
+            <h3>Main-program watchlist</h3>
+            <p>No official paper schedule or accepted-paper program is public yet. These are search themes for the eventual agenda, not invented talk titles.</p>
+          </div>
+          <div class="watch-grid">
+            <div class="watch-topic"><strong>Agentic multimodal reasoning</strong><span>Self-verification, planning, reflection, tool use</span></div>
+            <div class="watch-topic"><strong>Retrieval + visual search</strong><span>Agentic retrieval, grounding, multimodal RAG</span></div>
+            <div class="watch-topic"><strong>World models</strong><span>Dynamics, simulation, embodied prediction</span></div>
+            <div class="watch-topic"><strong>Evaluation + factuality</strong><span>Evidence alignment, calibration, judge reliability</span></div>
+            <div class="watch-topic"><strong>Real-time interfaces</strong><span>Streaming video, wearables, low-latency assistants</span></div>
+            <div class="watch-topic"><strong>Generative models</strong><span>Controllable generation and visual reasoning</span></div>
+          </div>
+        </div>
+      </div>
+    </section><section id="family">
+      <div class="wrap">
+        <div class="section-head">
+          <div>
+            <p class="eyebrow">Parallel week</p>
+            <h2>A conference plan for one parent, a real trip for the other three.</h2>
+          </div>
+          <p>Home Hotel Baltzar makes central Malmö the family's front door: old-town walks and Malmö C are close, while breakfast, fika, and dinner simplify split-parent conference days.</p>
+        </div>
+
+        <div class="family-split">
+          <aside class="conference-ticket">
+            <div class="ticket-top">
+              <p class="eyebrow">ECCV 2026</p>
+              <h3>Malmö Arena + Malmömässan</h3>
+              <p>Both venues are beside Hyllie station. Check the final program for the exact building and room assignment each day.</p>
+            </div>
+            <div class="ticket-row"><strong>Sep 8–9</strong><span>Workshops and tutorials</span></div>
+            <div class="ticket-row"><strong>Sep 10–12</strong><span>Main conference and expo</span></div>
+            <div class="ticket-row"><strong>Commute</strong><span>Baltzar → Malmö C → Hyllie, one direct train</span></div>
+            <div class="ticket-row"><strong>Buffer</strong><span>Leave the room about 35 minutes before the first session until the final schedule is known.</span></div>
+          </aside>
+
+          <div class="day-plan-list">
+            <article class="day-plan">
+              <div class="day-plan-date"><strong>08</strong><span>Tuesday</span></div>
+              <div><h3>Stay close: old town + Slottsparken</h3><p>An intentionally easy first day. Canal walks, playground time, casual lunch, and a simple return to the hotel if the children are done.</p></div>
+            </article>
+            <article class="day-plan">
+              <div class="day-plan-date"><strong>09</strong><span>Wednesday</span></div>
+              <div><h3>Lund day trip</h3><p>Direct train, compact old center, cathedral, university streets, and cafés. It scratches the “another destination” itch without another hotel or flight.</p></div>
+            </article>
+            <article class="day-plan">
+              <div class="day-plan-date"><strong>10</strong><span>Thursday</span></div>
+              <div><h3>Malmöhus Castle + aquarium</h3><p>A weather-proof museum day with enough variety for both ages. Pair with Kungsparken rather than stacking a second major attraction.</p></div>
+            </article>
+            <article class="day-plan">
+              <div class="day-plan-date"><strong>11</strong><span>Friday</span></div>
+              <div><h3>Västra Hamnen + Ribersborg</h3><p>Turning Torso, waterfront paths, playgrounds, and beach energy. Keep the plan flexible around wind and rain.</p></div>
+            </article>
+            <article class="day-plan">
+              <div class="day-plan-date"><strong>12</strong><span>Saturday</span></div>
+              <div><h3>Slow Malmö + final conference day</h3><p>Let the conference parent finish without a transfer deadline. Meet for dinner in the old town, pack after the children settle, and leave for Billund Sunday morning.</p></div>
+            </article>
+          </div>
+        </div>
+      </div>
+    </section><section id="billund" class="section-white">
+      <div class="wrap">
+        <div class="section-head">
+          <div>
+            <p class="eyebrow">Billund + Copenhagen finish</p>
+            <h2>Two Billund nights, then one protected Copenhagen night.</h2>
+          </div>
+          <p>The preferred sequence is Malmö → Billund early September 13, a partial LEGOLAND day, LEGO House on September 14, and Copenhagen on September 15. It keeps the family in Malmö through the full conference.</p>
+        </div>
+
+        <div class="image-feature">
+          <div class="image-feature-photo" role="img" aria-label="Exterior of LEGO House in Billund"></div>
+          <div class="image-feature-copy">
+            <span class="tag yellow">Date-specific sequence</span>
+            <h3>Park on arrival. House Monday. Copenhagen Tuesday.</h3>
+            <p>LEGOLAND is open Sunday, September 13, from 10:00–18:00, making a noon-ish arrival usable. LEGO House is open Monday, September 14, from 10:00–16:00. Both anchors are closed Tuesday, September 15.</p>
+            <div class="opening-pair">
+              <div class="opening-card critical"><strong>Sun · Sep 13</strong><span>LEGOLAND · 10:00–18:00 · partial day</span></div>
+              <div class="opening-card"><strong>Mon · Sep 14</strong><span>LEGO House · 10:00–16:00</span></div>
+            </div>
+          </div>
+        </div>
+
+        <div class="mini-steps" aria-label="Recommended Billund sequence">
+          <article class="mini-step"><strong>Saturday, Sep 12</strong><span>Finish ECCV without watching the clock. Eat and sleep in Malmö, with bags packed for a prompt Sunday departure.</span></article>
+          <article class="mini-step"><strong>Sunday, Sep 13</strong><span>Leave Malmö early, check bags at the Billund hotel, and use the remaining LEGOLAND hours. Six hours is likely enough for two early-elementary-age children.</span></article>
+          <article class="mini-step"><strong>Monday, Sep 14</strong><span>Book LEGO House at 10:00. Its indoor six-hour day is a better fit than trying to squeeze it around Sunday’s transfer.</span></article>
+          <article class="mini-step"><strong>Tuesday, Sep 15</strong><span>Check out and move east. Add Jelling or a Copenhagen afternoon, then sleep near central Copenhagen or the airport.</span></article>
+        </div>
+
+        <div class="program-watch">
+          <div>
+            <p class="eyebrow">Beyond the bricks</p>
+            <h3>Five good Billund-area alternatives</h3>
+            <p>Pick one only. The strongest choice depends on weather, transport, and whether this is a half-day before Copenhagen or a true extra day.</p>
+          </div>
+          <div class="watch-grid">
+            <div class="watch-topic"><strong>Lalandia Aquadome</strong><span>Best rain plan: tropical waterpark, children’s areas, and day tickets. Reserve ahead; day-guest capacity can close.</span></div>
+            <div class="watch-topic"><strong>WOW PARK Billund</strong><span>Best dry-day reset: forest play, nets, treehouses, slides, and underground routes. Check the exact September 15 hours.</span></div>
+            <div class="watch-topic"><strong>Kongernes Jelling</strong><span>Best change of pace: Viking history and UNESCO monuments. Under-18s are free; the museum is an easy walk from Jelling station.</span></div>
+            <div class="watch-topic"><strong>Givskud Zoo</strong><span>Best full-day car outing: safari and zoo, open in the 2026 September season. Too large for a casual stop on the way to CPH.</span></div>
+            <div class="watch-topic"><strong>Copenhagen encore</strong><span>Best flight-protection choice: leave Billund after breakfast and enjoy one familiar, low-planning city afternoon before SK935.</span></div>
+            <div class="watch-topic"><strong>Quiet Billund</strong><span>Playgrounds, sculpture paths, pastries, and hotel downtime can be exactly right after two major attractions and a conference week.</span></div>
+          </div>
+        </div>
+
+        <div class="flight-strategy">
+          <article class="strategy-card recommended">
+            <span class="tag">Recommended</span>
+            <h3>2 Billund nights + 1 Copenhagen night</h3>
+            <p>Stay in Malmö through September 13, use a partial LEGOLAND Sunday and full LEGO House Monday, then move to Copenhagen Tuesday. This is now the preferred balance.</p>
+          </article>
+          <article class="strategy-card">
+            <span class="tag blue">More Billund time</span>
+            <h3>Leave Malmö after ECCV on Sep 12</h3>
+            <p>This creates a third Billund night and two full LEGO days, but adds a late ground transfer after the final conference day. Keep it as an optional upgrade, not the default.</p>
+          </article>
+          <article class="strategy-card">
+            <span class="tag red">Avoid</span>
+            <h3>Sleep Billund on September 15</h3>
+            <p>Billund to Copenhagen Airport is roughly a three-hour trip before buffers. With SK935 confirmed at 12:45, the final morning becomes needlessly early and brittle.</p>
+          </article>
+        </div>
+
+        <p class="decision-note"><strong>Best September 15 variation:</strong> Jelling is the most distinctive cultural stop if transport and luggage are simple; Copenhagen is the safest default. Lalandia is excellent in rain but awkward on checkout day with wet gear. Save Givskud for a true extra day with a car.</p>
+      </div>
+    </section><section id="book" class="section-white">
+      <div class="wrap">
+        <div class="section-head">
+          <div>
+            <p class="eyebrow">Booking sequence</p>
+            <h2>Flights and Malmö are locked. Secure the remaining scarce pieces.</h2>
+          </div>
+          <p>The checklist saves locally in this browser. It is ordered by what can break the whole plan, not by what is most fun to shop for.</p>
+        </div>
+
+        <div class="checklist-shell">
+          <aside class="progress-card">
+            <h3>Trip readiness</h3>
+            <p>Check items as they are resolved. Progress is stored only on this device.</p>
+            <span class="progress-number" id="progressNumber">0%</span>
+            <div class="progress-track" aria-hidden="true"><div class="progress-fill" id="progressFill" style="width: 0%;"></div></div>
+          </aside>
+
+          <div class="checklist" id="checklist">
+            <label class="check-item"><input type="checkbox" data-check="flights" checked disabled><span class="check-copy"><strong>SAS flights booked</strong><span>SK936 + SK1426 outbound and SK935 nonstop home are confirmed for four travelers. Approximate paid total: $6.1k.</span></span><span class="priority later">Booked</span></label>
+            <label class="check-item"><input type="checkbox" data-check="malmo-hotel" checked disabled><span class="check-copy"><strong>Home Hotel Baltzar booked · Sep 7–13</strong><span>Junior Suite for four · approximately $2.8k · free cancellation until Sep 5 at 11:59pm local. Reservation number redacted.</span></span><span class="priority later">Booked</span></label>
+            <label class="check-item"><input type="checkbox" data-check="stockholm-hotel"><span class="check-copy"><strong>Hold Scandic Continental Superior Family · Sep 4–7</strong><span>First choice for a jet-lagged arrival: true four-person room with bunk bed and blackout curtains directly at Stockholm Central. Compare Nordic Light Deluxe King and Radisson Royal Viking Family Room before the refundable deadline.</span></span><span class="priority">Now</span></label>
+            <label class="check-item"><input type="checkbox" data-check="billund-hotel"><span class="check-copy"><strong>Hold Billund for Sep 13–15</strong><span>Choose a base that will hold bags before check-in so the partial September 13 LEGOLAND day remains usable.</span></span><span class="priority">Now</span></label>
+            <label class="check-item"><input type="checkbox" data-check="cph-hotel"><span class="check-copy"><strong>Hold Copenhagen for Sep 15</strong><span>Central Copenhagen is more enjoyable; Kastrup is safer if the family wants a frictionless SK935 morning.</span></span><span class="priority">Now</span></label>
+            <label class="check-item"><input type="checkbox" data-check="transfer"><span class="check-copy"><strong>Book Stockholm → Malmö; price Malmö → Billund</strong><span>SJ direct trains take about 4½ hours; current family fares are dynamic. Compare driver and one-way rental for September 13.</span></span><span class="priority soon">Soon</span></label>
+            <label class="check-item"><input type="checkbox" data-check="lego"><span class="check-copy"><strong>Book LEGOLAND + LEGO House entries</strong><span>Use a partial LEGOLAND day September 13 and LEGO House September 14. Both anchors are closed September 15.</span></span><span class="priority soon">Soon</span></label>
+            <label class="check-item"><input type="checkbox" data-check="eccv"><span class="check-copy"><strong>Register and lock the Sep 8–9 workshop plan</strong><span>Primary plan: Multimodal Digital Agents on Tuesday and World Models for Embodied AI on Wednesday.</span></span><span class="priority">Now</span></label>
+            <label class="check-item"><input type="checkbox" data-check="poster"><span class="check-copy"><strong>Capture the poster's exact assignment</strong><span>Date, session, time, room, and board are still TBA; watch the author inbox and official program. Paper identity is redacted publicly.</span></span><span class="priority soon">Soon</span></label>
+            <label class="check-item"><input type="checkbox" data-check="rail"><span class="check-copy"><strong>Install rail apps and plan airport tickets</strong><span>Use Skånetrafiken / Öresundståg for southern Sweden and cross-border travel; carry valid ID.</span></span><span class="priority later">Later</span></label>
+            <label class="check-item"><input type="checkbox" data-check="dinner"><span class="check-copy"><strong>Pick one Stockholm classic dinner</strong><span>Tradition in Gamla Stan is a straightforward first-timer option; keep the other meals flexible.</span></span><span class="priority later">Later</span></label>
+          </div>
+        </div>
+      </div>
+    </section><section id="sources" class="section-blue">
+      <div class="wrap">
+        <div class="section-head">
+          <div>
+            <p class="eyebrow">Planning references</p>
+            <h2>Official sources behind the working assumptions.</h2>
+          </div>
+          <p>Schedules and availability can change. Recheck every time-sensitive item before buying a nonrefundable fare or room.</p>
+        </div>
+
+        <div class="sources-grid">
+          <div class="source-group">
+            <h3>ECCV</h3>
+            <ul>
+              <li><a href="https://eccv.ecva.net/Conferences/2026/Dates" target="_blank" rel="noreferrer">ECCV meeting dates</a></li>
+              <li><a href="https://eccv.ecva.net/Conferences/2026/Registration" target="_blank" rel="noreferrer">ECCV registration and current fees</a></li>
+              <li><a href="https://eccv.ecva.net/Conferences/2026/Venues" target="_blank" rel="noreferrer">Malmö Arena + Malmömässan venue details</a></li>
+              <li><a href="https://eccv.ecva.net/Conferences/2026/Workshops" target="_blank" rel="noreferrer">September 8–9 workshop list</a></li>
+              <li><a href="https://eccv.ecva.net/Conferences/2026/Tutorials" target="_blank" rel="noreferrer">September 8–9 tutorial list</a></li>
+              <li><a href="https://allenai.org/newsletters/2026-07-newsletter" target="_blank" rel="noreferrer">Multimodal Digital Agents description + speakers</a></li>
+              <li><a href="https://beamv2-eccv-workshop.github.io/" target="_blank" rel="noreferrer">BEAM 2 workshop schedule</a></li>
+              <li><a href="https://eccv26wmeai.github.io/" target="_blank" rel="noreferrer">World Models for Embodied AI</a></li>
+            </ul>
+          </div>
+          <div class="source-group">
+            <h3>SAS flight checks</h3>
+            <ul>
+              <li><a href="https://www.flysas.com/en/fly-with-us/ticket-options/ticket-types/" target="_blank" rel="noreferrer">SAS Light ticket rules and inclusions</a></li>
+              <li><a href="https://www.flight.info/SK936" target="_blank" rel="noreferrer">SK936 planning schedule · SFO to CPH</a></li>
+              <li><a href="https://www.directflights.com/CPH-ARN/36/2026/SK/noreturn" target="_blank" rel="noreferrer">September 4 SAS CPH → ARN schedule · SK1426 at 13:50</a></li>
+              <li><a href="https://www.flight.info/SK1426" target="_blank" rel="noreferrer">SK1426 planning schedule · 13:50–15:05</a></li>
+              <li><a href="https://www.sas.dk/flyrejser/kobenhavn/stockholm" target="_blank" rel="noreferrer">SAS Copenhagen → Stockholm route information</a></li>
+              <li><a href="https://www.directflights.com/CPH-SFO" target="_blank" rel="noreferrer">SK935 nonstop planning schedule · CPH to SFO</a></li>
+              <li>The private booking confirmation is the controlling itinerary; third-party schedule pages remain planning cross-checks only.</li>
+            </ul>
+          </div>
+          <div class="source-group">
+            <h3>Rail + transfers</h3>
+            <ul>
+              <li><a href="https://www.oresundstag.se/en/travel-information/timetables" target="_blank" rel="noreferrer">2026 Öresundståg timetables</a></li>
+              <li><a href="https://www.oresundstag.se/en/customer-support/faq/" target="_blank" rel="noreferrer">Öresundståg border-control FAQ</a></li>
+              <li><a href="https://www.sj.se/en/search-journey/choose-journey/Stockholm%20Central/Malm%C3%B6%20Central/2026-09-07" target="_blank" rel="noreferrer">SJ live Stockholm–Malmö results · September 7</a></li>
+              <li><a href="https://swedish-rails-en-prod.cxoneexpert.ai/Tickets_and_purchase/Does_SJ_have_any_discount_for_children%3F" target="_blank" rel="noreferrer">SJ family discount details</a></li>
+              <li><a href="https://swedish-rails-en-prod.cxoneexpert.ai/Tickets_and_purchase/When_does_SJ_release_their_tickets%3F" target="_blank" rel="noreferrer">SJ ticket release window</a></li>
+              <li><a href="https://www.dsb.dk/en/kundeservice/sporgsmal-og-svar/does-billund-have-a-train-station/" target="_blank" rel="noreferrer">DSB: Billund–Vejle bus connection</a></li>
+              <li><a href="https://www.dsb.dk/en/train-rides-in-denmark/vejle-copenhagen/" target="_blank" rel="noreferrer">DSB: Vejle–Copenhagen train</a></li>
+            </ul>
+          </div>
+          <div class="source-group">
+            <h3>Billund dates + alternatives</h3>
+            <ul>
+              <li><a href="https://www.legoland.dk/en/plan-your-day/pre-visit/opening-hours/" target="_blank" rel="noreferrer">LEGOLAND 2026 opening calendar</a></li>
+              <li><a href="https://legohouse.com/en-gb/plan-your-visit/opening-hours" target="_blank" rel="noreferrer">LEGO House 2026 opening calendar</a></li>
+              <li><a href="https://www.lalandia.dk/en/billund/go-exploring/the-aquadome" target="_blank" rel="noreferrer">Lalandia Aquadome day visits</a></li>
+              <li><a href="https://wowpark.dk/en" target="_blank" rel="noreferrer">WOW PARK Billund</a></li>
+              <li><a href="https://www.givskudzoo.dk/da/besoeg-zoo/aabningstider/" target="_blank" rel="noreferrer">Givskud Zoo 2026 season</a></li>
+              <li><a href="https://kongernesjelling.dk/en/visit-us" target="_blank" rel="noreferrer">Kongernes Jelling visitor information</a></li>
+            </ul>
+          </div>
+          <div class="source-group">
+            <h3>Lodging details</h3>
+            <ul>
+              <li>The private booking record confirms Home Hotel Baltzar, Junior Suite, September 7–13 for four guests; the reservation identifier is redacted.</li>
+              <li><a href="https://www.radissonhotels.com/en-us/hotels/radisson-blu-malmo/rooms" target="_blank" rel="noreferrer">Radisson Blu Malmö room sizes and family occupancy</a></li>
+              <li><a href="https://www.radissonhotels.com/en-us/hotels/radisson-blu-malmo" target="_blank" rel="noreferrer">Radisson Blu Malmö location and 600 m station walk</a></li>
+              <li><a href="https://www.strawberryhotels.com/hotels/sweden/malmo/comfort-hotel-malmo/" target="_blank" rel="noreferrer">Comfort Hotel Malmö Family Room, meals, and cleaning details</a></li>
+              <li><a href="https://www.strawberryhotels.com/hotels/sweden/malmo/home-hotel-baltzar/" target="_blank" rel="noreferrer">Home Hotel Baltzar rooms, included meals, and window caveat</a></li>
+              <li><a href="https://www.bestwestern.se/hotell/best-western-plus-hotel-noble-house-88158" target="_blank" rel="noreferrer">Noble House family rooms, breakfast, and kids' corner</a></li>
+              <li><a href="https://www.themorehotel.se/en/mazetti/hotellrum-mazetti/" target="_blank" rel="noreferrer">Mazetti room capacities + kitchens</a></li>
+              <li><a href="https://www.scandichotels.com/en/hotels/scandic-triangeln" target="_blank" rel="noreferrer">Scandic Triangeln family rooms</a></li>
+            </ul>
+          </div>
+          <div class="source-group">
+            <h3>Stockholm with kids + food</h3>
+            <ul>
+              <li><a href="https://www.arlandaexpress.se/biljetter/biljetter-priser" target="_blank" rel="noreferrer">Arlanda Express · 18-minute trip, current adult and child rules</a></li>
+              <li><a href="https://www.scandichotels.com/en/hotels/scandic-continental" target="_blank" rel="noreferrer">Scandic Continental · Superior Family room and station location</a></li>
+              <li><a href="https://nordiclighthotel.com/rooms-and-suites/" target="_blank" rel="noreferrer">Nordic Light · Deluxe King size, occupancy, and soundproofing</a></li>
+              <li><a href="https://www.radissonhotels.com/en-us/hotels/radisson-blu-stockholm-royal-viking" target="_blank" rel="noreferrer">Radisson Blu Royal Viking · Family Room and station access</a></li>
+              <li><a href="https://www.vasamuseet.se/en/visit/kids--families" target="_blank" rel="noreferrer">Vasa Museum for children and families</a></li>
+              <li><a href="https://www.junibacken.se/en/plan-your-visit/" target="_blank" rel="noreferrer">Junibacken hours and visit planning</a></li>
+              <li><a href="https://www.skansen.se/en/see-and-do/for-families-and-children/" target="_blank" rel="noreferrer">Skansen for families</a></li>
+              <li><a href="https://www.visitstockholm.com/see-do/activities/stockholm-for-kids/" target="_blank" rel="noreferrer">Visit Stockholm family guide</a></li>
+              <li><a href="https://visitsweden.com/where-to-go/middle-sweden/stockholm/food-and-drink-stockholm/" target="_blank" rel="noreferrer">Visit Sweden · Stockholm food and drink</a></li>
+              <li><a href="https://www.visitstockholm.com/eat-drink/cafes/fika-in-stockholm/" target="_blank" rel="noreferrer">Visit Stockholm fika guide</a></li>
+              <li><a href="https://www.visitstockholm.com/eat-drink/cafes/a-fika-evergreen-the-princess-cake/" target="_blank" rel="noreferrer">Princess cake history</a></li>
+              <li><a href="https://www.visitstockholm.com/eat-drink/restaurants/my-favorite-spots-to-enjoy-the-classics-of-swedish-cuisine/" target="_blank" rel="noreferrer">Classic Swedish restaurants</a></li>
+            </ul>
+          </div>
+          <div class="source-group">
+            <h3>Visual credits</h3>
+            <ul>
+              <li><a href="https://www.naturalearthdata.com/downloads/110m-cultural-vectors/110m-admin-0-countries/" target="_blank" rel="noreferrer">Map geometry · Natural Earth 1:110m</a></li>
+              <li><a href="https://commons.wikimedia.org/wiki/File:Oresund_Bridge_-_Malmo,_Sweden.jpg" target="_blank" rel="noreferrer">Öresund Bridge · Richard Dennis · CC BY 2.0</a></li>
+              <li><a href="https://commons.wikimedia.org/wiki/File:LEGO_house_exterior_01.jpg" target="_blank" rel="noreferrer">LEGO House · Sintakso · Wikimedia Commons</a></li>
+              <li><a href="https://commons.wikimedia.org/wiki/File:Malm%C3%B6_central_station.jpg" target="_blank" rel="noreferrer">Malmö Central · Jiří Komárek · CC BY-SA 4.0</a></li>
+            </ul>
+          </div>
+          <div class="source-group">
+            <h3>Important caveats</h3>
+            <ul>
+              <li>Home Hotel Baltzar is confirmed; availability for the remaining Stockholm, Billund, and Copenhagen stays is not asserted.</li>
+              <li>Stockholm hotel rankings use official room capacities and locations; confirm live September 4–7 inventory, exact bedding, and refundable pricing before booking.</li>
+              <li>Drive time and door-to-door commute times are planning estimates.</li>
+              <li>The main-conference program and poster session assignment are not yet public.</li>
+              <li>Flight times are tied to the private SAS reservation; recheck for operational schedule changes before travel.</li>
+              <li>Confirm the school calendar and passport validity.</li>
+            </ul>
+          </div>
+        </div>
+        <p class="as-of">Public planning edition updated August 15, 2026. The SAS itinerary and Home Hotel Baltzar stay are confirmed, with approximate combined booked costs of $8.9k. Passenger names, reservation identifiers, assigned seats, account credits, payment details, and the conference paper identity are omitted. Stockholm room configurations and Central-station access were refreshed from official Scandic Continental, Nordic Light, Radisson Blu Royal Viking, and Arlanda Express pages; live September 4–7 inventory is not asserted. A live SJ search for September 7 showed direct Stockholm–Malmö X 2000 journeys around 4h31–4h33 and family fares from SEK 2,196. The official calendars show both LEGO anchors open during September 13–14 and closed September 15.</p>
+      </div>
+    </section><section id="archive" class="archive-section">
+      <div class="wrap">
+        <div class="section-head">
+          <div>
+            <p class="eyebrow">Decision archive</p>
+            <h2>Useful history, out of the active planning flow.</h2>
+          </div>
+          <p>Once a choice is booked, the comparison work moves here. Expand it only if a reservation changes or the reasoning needs to be revisited.</p>
+        </div>
+
+        <details class="decision-archive-shell">
+          <summary>Open completed and superseded decisions</summary>
+          <div class="archive-body" id="decisionArchiveContent">
+            <details class="archive-item">
+              <summary>Earlier route scenarios</summary>
+              <div class="archive-item-copy">
+                <p>The booked flights and September 7–13 Malmö stay removed these from the active itinerary:</p>
+                <ul>
+                  <li>Leave Malmö on September 12 for three Billund nights—more LEGO time, but a rushed final-conference evening.</li>
+                  <li>Stay three Billund nights and transfer to CPH on flight morning—rejected because it adds too much risk to SK935.</li>
+                  <li>The retained framework keeps September 12 in Malmö, two Billund nights, and September 15 in Copenhagen.</li>
+                </ul>
+              </div>
+            </details>
+            <div class="archive-area-shell" id="malmoAreaArchive" aria-label="Archived Malmö base comparison"></div>
+            <div id="malmoHotelArchive" aria-label="Archived Malmö hotel comparison"></div>
+          </div>
+        </details>
+      </div>
+    </section></main>
+
+  <div class="modal-overlay" id="exportModal" hidden="">
+    <div class="modal-panel" role="dialog" aria-modal="true" aria-labelledby="exportTitle">
+      <div class="modal-head">
+        <div>
+          <p class="eyebrow">Portable brief</p>
+          <h2 id="exportTitle">Copyable Scandi ECCV trip plan</h2>
+        </div>
+        <div class="modal-actions">
+          <button class="modal-button copy" id="copyExport" type="button">Copy</button>
+          <button class="modal-button" id="closeExport" type="button">Close</button>
+        </div>
+      </div>
+      <textarea class="export-text" id="exportText" readonly="" spellcheck="false"></textarea>
+    </div>
+  </div>
+
+  <script>
+    const chronologicalSectionOrder = [
+      "verdict",
+      "routes",
+      "map",
+      "bookings",
+      "stockholm",
+      "base",
+      "conference",
+      "family",
+      "billund",
+      "book",
+      "sources",
+      "archive"
+    ];
+    const tripMain = document.querySelector("main");
+    const archivedAreaComparison = document.querySelector("#base .rail-board");
+    const archivedHotelComparison = document.getElementById("hotels");
+    const malmoAreaArchive = document.getElementById("malmoAreaArchive");
+    const malmoHotelArchive = document.getElementById("malmoHotelArchive");
+    if (archivedAreaComparison && malmoAreaArchive) malmoAreaArchive.appendChild(archivedAreaComparison);
+    if (archivedHotelComparison && malmoHotelArchive) malmoHotelArchive.appendChild(archivedHotelComparison);
+    chronologicalSectionOrder.forEach((sectionId) => {
+      const section = document.getElementById(sectionId);
+      if (section && tripMain) tripMain.appendChild(section);
+    });
+
+    // Keep the pre-rendered fallback map current if the live D3 map cannot load.
+    document.querySelectorAll("#nordicMap .map-label-note").forEach((note) => {
+      if (note.textContent.trim() === "Radisson + ECCV") note.textContent = "Baltzar + ECCV";
+    });
+
+    const scenarios = {
+      reverse: {
+        dates: "Sep 3–16 · about 8 school days",
+        title: "Stockholm, ECCV, Billund, Copenhagen",
+        summary: "Three Stockholm nights, six Malmö nights, two Billund nights, and one Copenhagen night before the nonstop home.",
+        verdictTitle: "Locked framework",
+        verdictCopy: "The booked flights and September 7–13 Baltzar stay protect the conference and preserve the nonstop flight home.",
+        route: [
+          ["Stockholm", "Sep 4–7", "3 nights"],
+          ["Malmö", "Sep 7–13", "Baltzar + ECCV"],
+          ["Billund", "Sep 13–15", "2 nights"],
+          ["Copenhagen → SFO", "Sep 15–16", "SK935 nonstop"]
+        ],
+        days: [
+          ["Thu–Fri · Sep 3–4", "SK936 + SK1426", "Confirmed SFO → CPH → ARN itinerary, with SK1426 at 13:50–15:05 and a 1h50 protected connection."],
+          ["Fri–Mon · Sep 4–7", "Stockholm", "Gamla Stan arrival walk, Vasa + Djurgården, then one flexible family day."],
+          ["Mon · Sep 7", "Train to Malmö", "Direct X 2000 takes about 4½ hours; current family fares are roughly SEK 2,200–3,500."],
+          ["Tue–Sat · Sep 8–12", "ECCV", "Direct Malmö C → Hyllie commute; sleep in Malmö after the final program."],
+          ["Sun · Sep 13", "Malmö → LEGOLAND", "Transfer early and use a partial park day; official hours are 10:00–18:00."],
+          ["Mon · Sep 14", "LEGO House", "Book a full 10:00–16:00 visit."],
+          ["Tue–Wed · Sep 15–16", "Copenhagen + SK935", "Move east Tuesday, sleep in Copenhagen, and fly nonstop Wednesday."]
+        ]
+      },
+      posterSafe: {
+        dates: "Sep 3–16 · about 8 school days",
+        title: "Leave after ECCV for three Billund nights",
+        summary: "This variation checks out of the Malmö hotel on September 12, transfers west after the conference, and creates two full LEGO days.",
+        verdictTitle: "Verdict: more Billund, less calm",
+        verdictCopy: "It buys a full third night and avoids a partial park day, but restores the Saturday-evening transfer you prefer to avoid.",
+        route: [
+          ["Stockholm", "Sep 4–7", "3 nights"],
+          ["Malmö", "Sep 7–12", "5 nights"],
+          ["Billund", "Sep 12–15", "3 nights"],
+          ["Copenhagen → SFO", "Sep 15–16", "SK935 nonstop"]
+        ],
+        days: [
+          ["Thu–Mon · Sep 3–7", "Stockholm arrival", "Use SK1426 and the same three-night Stockholm plan."],
+          ["Mon–Sat · Sep 7–12", "Malmö + ECCV", "Check out Saturday and store luggage at the hotel during the final program."],
+          ["Sat · Sep 12", "Malmö → Billund", "Transfer after ECCV and sleep in Billund."],
+          ["Sun–Mon · Sep 13–14", "Two full LEGO days", "Use LEGO House and LEGOLAND in either order based on tickets and weather."],
+          ["Tue · Sep 15", "Copenhagen", "Both LEGO anchors are closed; transfer east and sleep near the airport route."],
+          ["Wed · Sep 16", "SK935", "Nonstop Copenhagen → San Francisco."],
+          ["Tradeoff", "Late transfer", "This is the better choice only if two full attraction days matter more than a relaxed final ECCV evening."]
+        ]
+      },
+      billundLate: {
+        dates: "Sep 3–16 · about 8 school days",
+        title: "Malmö through Sunday, then three Billund nights",
+        summary: "This preserves a relaxed ECCV finish and three Billund nights, but leaves the family in Billund on the morning of SK935.",
+        verdictTitle: "Verdict: not recommended",
+        verdictCopy: "The final transfer is about three hours before airport buffer; it undermines the entire reason for choosing the nonstop.",
+        route: [
+          ["Stockholm", "Sep 4–7", "3 nights"],
+          ["Malmö", "Sep 7–13", "6 nights"],
+          ["Billund", "Sep 13–16", "3 nights"],
+          ["CPH → SFO", "Sep 16", "Early transfer"]
+        ],
+        days: [
+          ["Thu–Mon · Sep 3–7", "Stockholm arrival", "Same protected SAS outbound and three-night Stockholm plan."],
+          ["Mon–Sun · Sep 7–13", "Malmö + ECCV", "No pressure to leave after Saturday’s program."],
+          ["Sun · Sep 13", "Billund arrival", "LEGO House may be partial depending on departure time."],
+          ["Mon · Sep 14", "LEGOLAND", "Use the full official operating day."],
+          ["Tue · Sep 15", "Non-LEGO day", "Lalandia, WOW PARK, Jelling, or quiet Billund; both LEGO anchors are closed."],
+          ["Wed · Sep 16", "Pre-dawn transfer", "Billund → CPH before SK935; high consequence if road or rail is disrupted."],
+          ["Better fix", "Sleep Copenhagen", "Drop one Billund night or depart Malmö Saturday to regain a protected final night."]
+        ]
+      }
+    };
+
+    const scenarioButtons = Array.from(document.querySelectorAll("[data-scenario]"));
+    const scenarioRoute = document.getElementById("scenarioRoute");
+    const scenarioDays = document.getElementById("scenarioDays");
+    let activeScenario = "reverse";
+
+    function renderScenario(key) {
+      const scenario = scenarios[key];
+      if (!scenario) return;
+      activeScenario = key;
+      document.getElementById("scenarioDates").textContent = scenario.dates;
+      document.getElementById("scenarioTitle").textContent = scenario.title;
+      document.getElementById("scenarioSummary").textContent = scenario.summary;
+      document.getElementById("scenarioVerdictTitle").textContent = scenario.verdictTitle;
+      document.getElementById("scenarioVerdictCopy").textContent = scenario.verdictCopy;
+      scenarioRoute.innerHTML = scenario.route.map((stop, index) => `
+        <div class="route-stop">
+          <div class="route-dot">${String(index + 1).padStart(2, "0")}</div>
+          <strong>${stop[0]}</strong>
+          <span>${stop[1]} · ${stop[2]}</span>
+        </div>`).join("");
+      scenarioDays.innerHTML = scenario.days.map((day) => `
+        <article class="scenario-day">
+          <div class="scenario-day-date">${day[0]}</div>
+          <strong>${day[1]}</strong>
+          <p>${day[2]}</p>
+        </article>`).join("");
+      scenarioButtons.forEach((button) => button.setAttribute("aria-pressed", String(button.dataset.scenario === key)));
+    }
+
+    scenarioButtons.forEach((button) => button.addEventListener("click", () => renderScenario(button.dataset.scenario)));
+    renderScenario("reverse");
+
+    const filterButtons = Array.from(document.querySelectorAll("[data-filter]"));
+    const hotelCards = Array.from(document.querySelectorAll(".hotel-card[data-area]"));
+    filterButtons.forEach((button) => {
+      button.addEventListener("click", () => {
+        const filter = button.dataset.filter;
+        filterButtons.forEach((item) => item.setAttribute("aria-pressed", String(item === button)));
+        hotelCards.forEach((card) => {
+          card.hidden = filter !== "all" && card.dataset.area !== filter;
+        });
+      });
+    });
+
+    const checkboxes = Array.from(document.querySelectorAll("[data-check]"));
+    const progressNumber = document.getElementById("progressNumber");
+    const progressFill = document.getElementById("progressFill");
+    const storageKey = "eccv-2026-trip-checklist-v2";
+
+    function loadChecklist() {
+      try {
+        const saved = JSON.parse(localStorage.getItem(storageKey) || "{}");
+        checkboxes.forEach((box) => {
+          if (box.dataset.check === "flights" || box.dataset.check === "malmo-hotel") {
+            box.checked = true;
+            return;
+          }
+          box.checked = Boolean(saved[box.dataset.check]);
+        });
+      } catch (error) {
+        // Local storage can be unavailable in private or restricted contexts.
+      }
+      updateProgress();
+    }
+
+    function saveChecklist() {
+      const state = {};
+      checkboxes.forEach((box) => { state[box.dataset.check] = box.checked; });
+      try { localStorage.setItem(storageKey, JSON.stringify(state)); } catch (error) {}
+      updateProgress();
+    }
+
+    function updateProgress() {
+      const done = checkboxes.filter((box) => box.checked).length;
+      const percent = Math.round((done / checkboxes.length) * 100);
+      progressNumber.textContent = `${percent}%`;
+      progressFill.style.width = `${percent}%`;
+    }
+
+    checkboxes.forEach((box) => box.addEventListener("change", saveChecklist));
+    loadChecklist();
+
+    const exportModal = document.getElementById("exportModal");
+    const exportText = document.getElementById("exportText");
+    const openExport = document.getElementById("openExport");
+    const closeExport = document.getElementById("closeExport");
+    const copyExport = document.getElementById("copyExport");
+    let lastFocusedElement = null;
+
+    function buildExportText() {
+      const scenario = scenarios[activeScenario];
+      const selectedChecks = checkboxes.filter((box) => box.checked).map((box) => box.dataset.check);
+      return `SCANDI ECCV 2026 — FAMILY TRIP WORKING BRIEF
+
+CORE DATES
+• Depart SFO: Thursday, September 3, 2026 on SAS SK936
+• Connect Copenhagen to Stockholm: Friday, September 4 on SAS SK1426, 13:50–15:05
+• Stockholm: September 4–7
+• ECCV workshops/tutorials: September 8–9
+• ECCV main conference: September 10–12
+• Malmö: September 7–13
+• Billund: September 13–15
+• Copenhagen final night: September 15
+• Fly home nonstop: Wednesday, September 16 on SK935
+• Family: four travelers with two young children
+• School impact: about 8 missed days, pending school-calendar confirmation
+
+COMPLETED BOOKINGS · PUBLIC SUMMARY
+• SAS Light itinerary confirmed for four travelers; reservation and seat details redacted
+• Sep 3–4: SK936 SFO 16:45 → CPH 12:00
+• Sep 4: SK1426 CPH 13:50 → ARN 15:05
+• Sep 16: SK935 CPH 12:45 → SFO 14:40 nonstop
+• Approximate airfare total: $6.1k
+• Home Hotel Baltzar: Sep 7–13 · Junior Suite · family of four; reservation identifier redacted
+• Approximate Baltzar total: $2.8k after an applied travel credit
+• Baltzar free cancellation: Sep 5 at 11:59pm Malmö time
+• Approximate booked-trip total: $8.9k; remaining hotels, rail, transfers, registration, and attractions not yet included
+
+CURRENT RECOMMENDATION
+• SK936 + SK1426 + SK935 are confirmed; the outbound connection is 1h50
+• First Stockholm hold: Scandic Continental Superior Family, September 4–7, on a refundable rate
+• Stockholm backups: Nordic Light Deluxe King, then Radisson Blu Royal Viking Family Room; verify exact children's beds
+• Arlanda Express: 18 minutes; current two-adult group fare SEK 460, with children 0–17 free when accompanied
+• Jet-lag arrival: Arlanda Express, check in around 16:30, short daylight walk, dinner around 17:30, bed around 19:30–20:30
+• Saturday: Vasa is the guaranteed anchor; add Junibacken only if the children still have energy
+• Sunday: choose Skansen OR an easier Gamla Stan + ferry day at breakfast; do not stack them
+• Take a direct X 2000 Stockholm → Malmö September 7; plan about 4½ hours
+• Live family fares checked August 9 ranged from SEK 2,196 to SEK 2,978 for early direct trains
+• Home Hotel Baltzar Junior Suite is booked September 7–13; confirm the sofa bed is prepared for both children
+• Baltzar → ECCV is about 22–28 minutes door to venue via Malmö C and Hyllie
+• Sleep in Malmö after ECCV on September 12; transfer to Billund early September 13
+• Sunday September 13: partial LEGOLAND day, open 10:00–18:00
+• Monday September 14: LEGO House, 10:00–16:00
+• Transfer Billund → Copenhagen September 15 and sleep there before SK935
+
+ECCV ATTENDANCE PLAN
+• Sep 8 primary: Multimodal Digital Agents, full day
+• Sep 8 pivot: BEAM 2 only after its 09:00–13:00 listing is reconciled with ECCV's PM listing
+• Sep 9 primary: How to Build Effective World Models for Embodied AI, full day
+• Sep 9 split alternative: Multimodal Reasoning and Slow Thinking AM; Wearables AI or Evaluating Visual Foundation Models PM
+• An author poster is confirmed; the paper number and title are redacted in this public edition
+• Exact poster date, session, time, room, and board: TBA
+• Main-program watch: agents, multimodal reasoning, retrieval, world models, evaluation, real-time interfaces, generative models
+
+SELECTED SCENARIO
+${scenario.title}
+${scenario.dates}
+${scenario.summary}
+
+ACTIVE STOCKHOLM LODGING ORDER
+1. Scandic Continental — Superior Family; true four-person bunk setup, blackout curtains, directly at Central
+2. Nordic Light — Deluxe King; 28–35 m² and soundproofed, but verify the extra-bed layout
+3. Radisson Blu Royal Viking — Family Room; 28 m² and 150 m from Central, but verify children's beds and pool reopening
+• Malmö lodging decision is complete: Home Hotel Baltzar Junior Suite is booked; its old comparison is archived in the page
+
+FLIGHTS
+• Confirmed Sep 3: SK936 SFO → CPH, 16:45–12:00 (+1 day)
+• Confirmed Sep 4: SK1426 CPH → ARN, 13:50–15:05
+• Confirmed Sep 16: SK935 CPH → SFO, 12:45–14:40 nonstop
+• Recheck the private SAS reservation for operational schedule changes before travel
+
+OPEN DECISIONS
+• Book a refundable Stockholm family room for September 4–7; first hold is Scandic Continental Superior Family
+• Preferred September 7 Stockholm → Malmö departure and live fare
+• Confirm Baltzar sofa-bed preparation and any property-collected mandatory fees before Sep 5
+• Billund and Copenhagen family rooms
+• Sep 13 Malmö → Billund transfer method
+• Exact ECCV poster assignment and main-program selections
+
+CHECKLIST ITEMS COMPLETED ON THIS DEVICE
+${selectedChecks.length ? selectedChecks.map((item) => `• ${item}`).join("\n") : "• None yet"}
+
+RESEARCH CHECKED
+August 10, 2026. Flights and Home Hotel Baltzar are confirmed. Stockholm room configurations were refreshed from official hotel pages, but live September 4–7 inventory and pricing are not asserted; reconfirm before purchase.`;
+    }
+
+    function openExportModal() {
+      lastFocusedElement = document.activeElement;
+      exportText.value = buildExportText();
+      exportModal.hidden = false;
+      exportModal.classList.add("is-open");
+      document.body.classList.add("modal-lock");
+      closeExport.focus();
+    }
+
+    function closeExportModal() {
+      exportModal.classList.remove("is-open");
+      exportModal.hidden = true;
+      document.body.classList.remove("modal-lock");
+      if (lastFocusedElement) lastFocusedElement.focus();
+    }
+
+    async function copyExportText() {
+      exportText.select();
+      try {
+        await navigator.clipboard.writeText(exportText.value);
+        copyExport.textContent = "Copied";
+      } catch (error) {
+        document.execCommand("copy");
+        copyExport.textContent = "Copied";
+      }
+      window.setTimeout(() => { copyExport.textContent = "Copy"; }, 1500);
+    }
+
+    openExport.addEventListener("click", openExportModal);
+    closeExport.addEventListener("click", closeExportModal);
+    copyExport.addEventListener("click", copyExportText);
+    exportModal.addEventListener("click", (event) => { if (event.target === exportModal) closeExportModal(); });
+    document.addEventListener("keydown", (event) => { if (event.key === "Escape" && !exportModal.hidden) closeExportModal(); });
+  </script>
+  <script type="module">
+    import * as d3 from "https://cdn.jsdelivr.net/npm/d3@7.9.0/+esm";
+    import { feature } from "https://cdn.jsdelivr.net/npm/topojson-client@3.1.0/+esm";
+    // Published Natural Earth geometry from @d3-maps/atlas 1.0.0 (countries-110m).
+    const worldTopology = {type:"Topology",arcs:[[[99999,42577],[0,-282],[-177,-141],[-177,-122],[-36,215],[139,118],[88,32],[163,180]],[[99478,41749],[69,95],[96,-167],[-46,-300],[-172,-79],[-153,71],[-27,253],[107,198],[126,-71]],[[57,42603],[-34,-277],[-23,-31],[0,282],[57,26]],[[59417,51282],[47,-63],[1007,-1173],[19,-334],[399,-576]],[[60889,49136],[-128,-710],[16,-326],[178,-210],[8,-149],[-76,-348],[16,-175],[-18,-275],[97,-361],[115,-568],[101,-126]],[[61198,45888],[0,0],[-221,-334],[-303,-224],[-167,10],[-99,-173],[-193,-15],[-73,-73],[-334,163],[-209,-47]],[[59599,45195],[-77,783],[-95,269],[-55,159],[-273,108]],[[59099,46514],[-157,172],[-177,97],[-111,97],[-116,146]],[[58538,47026],[0,0],[-150,726],[-161,323],[-55,334],[27,299],[-50,530]],[[58149,49238],[115,27],[101,209],[108,300],[69,121],[-3,187],[-60,130],[-16,227]],[[58463,50439],[0,0],[80,73],[16,339],[-110,325]],[[58449,51176],[98,69],[304,-7],[566,44]],[[47592,67756],[1,-38],[-6,-112]],[[47587,67606],[-1,-872],[-911,30],[9,-1474],[-261,-51],[-68,-296],[53,-832],[-1088,4],[-60,-192]],[[45260,63923],[12,243]],[[45272,64166],[5,-1],[625,46],[33,208],[114,258],[92,796],[386,621],[131,726],[86,42],[91,449],[234,62],[100,-75],[126,0],[90,131],[172,19],[-7,308],[42,0]],[[15878,80048],[-38,1],[-537,566],[-199,248],[-503,239],[-155,510],[40,353],[-356,245],[-48,464],[-336,419],[-6,296]],[[13740,83389],[0,0],[154,278],[-7,363],[-473,367],[-284,657],[-173,413],[-255,259],[-187,236],[-147,298],[-279,-187],[-270,-321],[-247,378],[-194,252],[-271,160],[-273,17],[1,3279],[2,2137],[0,0]],[[10837,91975],[518,-139],[438,-277],[289,-53],[244,241],[336,179],[413,-70],[416,253],[455,144],[191,-239],[207,134],[62,272],[192,-62],[470,-516],[369,390],[38,-437],[341,95],[105,168],[337,-33],[424,-242],[650,-211],[383,-98],[272,37],[374,-292],[-390,-286],[502,-123],[750,68],[236,100],[296,-345],[302,291],[-283,245],[179,197],[338,26],[223,58],[224,-138],[279,-312],[310,46],[491,-260],[431,91],[405,-13],[-32,358],[247,100],[431,-195],[-2,-545],[177,459],[223,-15],[126,579],[-298,355],[-324,233],[22,636],[329,418],[366,-92],[281,-255],[378,-649],[-247,-283],[517,-116],[-1,-589],[371,451],[332,-371],[-83,-427],[269,-388],[290,416],[202,497],[16,632],[394,-44],[411,-85],[373,-286],[17,-285],[-207,-307],[196,-309],[-36,-280],[-544,-403],[-386,-88],[-287,173],[-83,-289],[-268,-486],[-81,-252],[-322,-389],[-397,-38],[-220,-244],[-18,-374],[-323,-72],[-340,-467],[-301,-648],[-108,-454],[-16,-669],[409,-96],[125,-539],[130,-437],[388,114],[517,-250],[277,-219],[199,-272],[348,-158],[294,-243],[459,-33],[302,-56],[-45,-499],[86,-578],[201,-645],[414,-547],[214,188],[150,592],[-145,909],[-196,303],[445,270],[314,404],[154,401],[-23,385],[-188,489],[-338,434],[328,603],[-121,522],[-93,899],[194,133],[476,-157],[286,-56],[230,152],[258,-196],[342,-333],[85,-224],[495,-44],[-8,-483],[92,-728],[254,-90],[201,-339],[402,319],[266,636],[184,267],[216,-514],[362,-734],[307,-691],[-112,-362],[370,-325],[250,-329],[442,-149],[179,-183],[110,-488],[216,-76],[112,-217],[20,-647],[-202,-217],[-199,-202],[-458,-205],[-349,-473],[-470,-93],[-594,121],[-417,4],[-287,-40],[-233,-413],[-354,-255],[-401,-762],[-320,-532],[236,95],[446,756],[583,480],[415,58],[246,-283],[-262,-387],[88,-620],[91,-435],[361,-287],[459,83],[278,647],[19,-417],[180,-209],[-344,-377],[-615,-343],[-276,-233],[-310,-415],[-211,43],[-11,487],[483,476],[-445,-19],[-309,-70]],[[31350,77823],[-181,326],[0,785],[-123,166],[-187,-98],[-92,152],[-212,-435],[-84,-448],[-99,-262],[-118,-89],[-89,-29],[-28,-142],[-512,-1],[-422,-4],[-125,-106],[-294,-414],[-34,-45],[-89,-225],[-255,0],[-273,-2],[-125,-91],[44,-113],[25,-176],[-5,-58],[-363,-287],[-286,-90],[-323,-308],[-70,0],[-94,91],[-31,82],[6,60],[61,202],[131,317],[81,340],[-56,500],[-59,523],[-290,270],[35,103],[-41,70],[-76,0],[-56,91],[-14,137],[-54,-60],[-75,18],[17,57],[-65,57],[-27,151],[-216,185],[-224,191],[-272,223],[-261,209],[-248,-163],[-91,-6],[-342,150],[-225,-75],[-269,179],[-284,91],[-194,36],[-86,97],[-49,317],[-94,-3],[-1,-221],[-575,0],[-951,0],[-944,-1],[-833,1],[-834,0],[-819,0],[-847,0],[-273,0],[-825,0],[-788,0]],[[26668,87795],[207,265],[381,-5],[-6,-112],[-325,-317],[-196,13],[-61,156]],[[27840,93755],[-306,306],[12,207],[133,38],[636,-62],[479,-316],[25,-159],[-296,16],[-299,13],[-304,-78],[-80,35]],[[27690,87583],[107,173],[114,-13],[70,-118],[-108,-302],[-123,49],[-73,171],[13,40]],[[23996,95009],[-151,-223],[-403,43],[-337,150],[148,259],[399,155],[243,-202],[101,-182]],[[23933,96472],[-126,-17],[-521,37],[-74,161],[559,-9],[195,-107],[-33,-65]],[[23124,97189],[332,-200],[-76,-208],[-411,-119],[-226,134],[-119,216],[-22,238],[360,-23],[162,-38]],[[25514,94670],[-449,71],[-738,186],[-96,316],[-34,286],[-279,251],[-574,70],[-322,179],[104,236],[573,-36],[308,-186],[547,2],[240,-190],[-64,-216],[319,-130],[177,-137],[374,-26],[406,-48],[441,125],[566,49],[451,-40],[298,-218],[62,-238],[-174,-153],[-414,-124],[-355,70],[-797,-88],[-570,-11]],[[19093,96836],[392,-90],[-93,-172],[-518,-166],[-411,186],[224,183],[406,59]],[[19177,97211],[361,-116],[-339,-113],[-461,1],[5,82],[285,173],[149,-27]],[[34555,81382],[-148,-363],[-184,-504],[181,195],[187,-124],[-98,-200],[247,-158],[128,140],[277,-177],[-86,-422],[194,99],[36,-306],[86,-358],[-117,-507],[-125,-21],[-183,109],[60,471],[-77,73],[-322,-499],[-166,20],[196,270],[-267,140],[-298,-34],[-539,17],[-43,171],[173,202],[-121,157],[234,347],[287,917],[172,328],[241,198],[129,-25],[-54,-156]],[[26699,89325],[304,-198],[318,-179],[25,-274],[204,45],[199,-191],[-247,-181],[-432,138],[-156,259],[-275,-306],[-396,-298],[-95,337],[-377,-55],[242,284],[35,454],[95,527],[201,-47],[51,-253],[143,89],[161,-151]],[[28119,93496],[263,228],[616,-291],[383,-274],[36,-252],[515,131],[290,-367],[670,-228],[242,-232],[263,-539],[-510,-268],[654,-376],[441,-127],[400,-529],[437,-38],[-87,-404],[-487,-669],[-342,246],[-437,554],[-359,-72],[-35,-330],[292,-335],[377,-265],[114,-153],[181,-570],[-96,-414],[-350,156],[-697,461],[393,-496],[289,-348],[45,-201],[-753,230],[-596,334],[-337,281],[97,162],[-414,296],[-405,280],[5,-167],[-803,-92],[-235,198],[183,424],[522,10],[571,74],[-92,205],[96,287],[360,561],[-77,255],[-107,197],[-425,280],[-563,196],[178,145],[-294,358],[-245,33],[-219,196],[-149,-170],[-503,-74],[-1011,129],[-588,169],[-450,87],[-231,202],[290,263],[-394,2],[-88,583],[213,515],[286,235],[717,154],[-204,-373],[219,-359],[256,465],[704,236],[477,-596],[-42,-377],[550,168]],[[23749,94522],[579,-20],[530,-140],[-415,-513],[-331,-112],[-298,-430],[-317,21],[-173,506],[4,287],[145,244],[276,157]],[[15873,95663],[0,0],[472,431],[570,373],[426,-8],[381,85],[-38,-443],[-214,-199],[-259,-29],[-517,-246],[-444,-88],[-377,124]],[[13136,82950],[267,46],[-84,-654],[242,-463],[-111,1],[-167,264],[-103,265],[-140,179],[-51,253],[16,184],[131,-75]],[[20696,97498],[546,-79],[751,-210],[212,-274],[108,-240],[-453,64],[-457,187],[-619,21],[268,171],[-335,139],[-21,221]],[[15692,79765],[-140,-80],[-456,262],[-84,204],[-248,202],[-50,164],[-286,103],[-107,314],[24,133],[291,-125],[171,-88],[261,-61],[94,-198],[138,-274],[277,-238],[115,-318]],[[16239,94703],[397,-119],[709,-32],[270,-167],[298,-243],[-349,-145],[-681,-405],[-344,-403],[0,-251],[-731,-278],[-147,253],[-641,304],[119,244],[192,421],[241,378],[-272,353],[939,90]],[[20050,95507],[247,97],[291,-25],[49,-282],[-169,-274],[-940,-89],[-701,-249],[-423,-13],[-35,187],[577,255],[-1255,-69],[-389,103],[379,563],[262,161],[782,-194],[493,-341],[485,-44],[-397,551],[255,210],[286,-67],[94,-275],[109,-205]],[[20410,93912],[311,-232],[175,-561],[86,-406],[466,-285],[502,-273],[-31,-253],[-456,-47],[178,-221],[-94,-211],[-503,90],[-478,156],[-322,-35],[-522,-196],[-704,-86],[-494,-54],[-151,271],[-379,157],[-246,-64],[-343,456],[185,61],[429,99],[392,-26],[362,100],[-537,135],[-594,-46],[-394,11],[-146,213],[644,230],[-428,-8],[-485,152],[233,431],[193,229],[744,351],[284,-111],[-139,-270],[618,174],[386,-291],[314,294],[254,-188],[227,-566],[140,238],[-197,590],[244,85],[276,-93]],[[22100,93699],[-306,377],[329,279],[331,-122],[496,73],[72,-167],[-259,-276],[420,-248],[-50,-518],[-455,-223],[-268,48],[-192,220],[-690,444],[5,185],[567,-72]],[[20389,94214],[372,23],[211,-126],[-244,-381],[-434,404],[95,80]],[[22639,96011],[212,-267],[9,-295],[-127,-429],[-458,-59],[-298,92],[5,336],[-455,-44],[-18,445],[299,-18],[419,197],[390,-34],[22,76]],[[23329,98247],[192,175],[285,41],[-122,132],[646,29],[355,-308],[468,-123],[455,-109],[220,-380],[334,-186],[-381,-171],[-513,-434],[-492,-41],[-575,74],[-299,235],[4,208],[220,154],[-508,-5],[-306,192],[-176,261],[193,256]],[[24559,98991],[413,110],[324,18],[545,94],[409,214],[344,-30],[300,-161],[211,311],[367,92],[498,64],[849,24],[148,-63],[802,98],[601,-37],[602,-36],[742,-45],[597,-74],[508,-156],[-12,-154],[-678,-250],[-672,-117],[-251,-129],[605,3],[-656,-349],[-452,-163],[-476,-470],[-573,-96],[-177,-117],[-841,-62],[383,-72],[-192,-103],[230,-284],[-264,-198],[-429,-163],[-132,-225],[-388,-172],[39,-130],[475,22],[6,-141],[-742,-345],[-726,159],[-816,-89],[-414,69],[-525,30],[-35,277],[514,130],[-137,415],[170,41],[742,-249],[-379,370],[-450,110],[225,223],[492,137],[79,201],[-392,225],[-118,297],[759,-25],[220,-63],[433,210],[-625,67],[-972,-37],[-491,196],[-232,232],[-324,169],[-61,197]],[[29106,90669],[-180,-170],[-312,-29],[-69,282],[118,323],[255,80],[217,-160],[3,-246],[-32,-80]],[[23262,91847],[169,-220],[-173,-202],[-374,175],[-226,-63],[-380,259],[245,178],[194,250],[295,-164],[166,-103],[84,-110]],[[32078,80550],[96,49],[365,-145],[284,-240],[8,-106],[-135,-10],[-360,180],[-258,272]],[[32218,78916],[97,-279],[202,-78],[257,16],[-137,-236],[-102,-37],[-353,244],[-69,193],[105,177]],[[13740,83389],[0,0],[-153,217],[-245,183],[-78,503],[-358,466],[-150,543],[-267,38],[-441,14],[-326,165],[-574,598],[-266,109],[-486,206],[-385,-49],[-546,264],[-330,246],[-309,-122],[58,-400],[-154,-37],[-321,-120],[-245,-195],[-308,-122],[-39,339],[125,565],[295,177],[-76,145],[-354,-321],[-190,-383],[-400,-410],[203,-280],[-262,-413],[-299,-241],[-278,-176],[-69,-255],[-434,-297],[-87,-271],[-325,-246],[-191,44],[-259,-160],[-282,-196],[-231,-193],[-477,-164],[-43,96],[304,270],[271,177],[296,315],[345,65],[137,236],[385,345],[62,115],[205,204],[48,437],[141,340],[-320,-175],[-90,99],[-150,-209],[-181,292],[-75,-207],[-104,287],[-278,-230],[-170,0],[-24,343],[50,211],[-179,205],[-361,-110],[-235,270],[-190,138],[-1,327],[-214,245],[108,331],[226,322],[99,295],[225,42],[191,-92],[224,278],[201,-50],[212,179],[-52,263],[-155,104],[205,222],[-170,-7],[-295,-125],[-85,-127],[-219,127],[-392,-65],[-407,138],[-117,232],[-351,334],[390,241],[620,282],[228,0],[-38,-288],[586,22],[-225,357],[-342,219],[-197,288],[-267,246],[-381,182],[155,302],[493,19],[350,262],[66,280],[284,274],[271,66],[526,256],[256,-39],[427,307],[421,-121],[201,-260],[123,112],[469,-35],[-16,-132],[425,-98],[283,57],[585,-182],[534,-54],[214,-75],[370,94],[421,-173],[302,-81],[0,0]],[[31350,77823],[48,-189],[-296,-279],[-286,-198],[-293,-171],[-147,-342],[-47,-129],[-3,-306],[92,-305],[115,-14],[-29,210],[83,-128],[-22,-165],[-188,-93],[-133,11],[-205,-100],[-121,-29],[-162,-28],[-231,-167],[408,108],[82,-109],[-389,-173],[-177,-1],[8,71],[-84,-160],[82,-26],[-60,-414],[-203,-443],[-20,148],[-61,30],[-91,144],[57,-310],[69,-103],[5,-217],[-89,-224],[-157,-460],[-25,23],[86,392],[-142,220],[-33,478],[-53,-249],[59,-365],[-183,90],[191,-185],[12,-548],[79,-40],[29,-199],[39,-577],[-176,-427],[-288,-171],[-182,-338],[-139,-37],[-141,-211],[-39,-193],[-305,-374],[-157,-274],[-131,-342],[-43,-409],[50,-400],[92,-492],[124,-408],[1,-249],[132,-668],[-9,-388],[-12,-224],[-69,-352],[-83,-73],[-137,70],[-44,253],[-105,132],[-148,496],[-129,440],[-42,225],[57,383],[-77,316],[-217,482],[-108,89],[-281,-262],[-49,29],[-135,269],[-174,142],[-314,-72],[-247,63],[-212,-39],[-114,-90],[50,-153],[-5,-234],[59,-113],[-53,-76],[-103,85],[-104,-109],[-202,17],[-207,305],[-242,-72],[-202,133],[-173,-40],[-234,-135],[-253,-427],[-276,-248],[-152,-275],[-63,-259],[-3,-397],[14,-277],[52,-196],[-108,-17]],[[22908,66710],[-197,127],[-217,178],[-78,271],[-61,403],[-164,328],[-96,338],[-139,394],[-196,230],[-227,-11],[-175,-455],[-230,172],[-144,174],[-69,317],[-92,301],[-165,253],[-142,182],[-102,204],[-481,0],[0,-237],[-221,0],[-552,-5],[-634,406],[-419,280],[26,113],[-353,-63],[-316,-44]],[[17464,70566],[-46,294],[-180,331],[-130,69],[-30,165],[-156,29],[-100,156],[-258,57],[-71,93],[-33,316],[-270,578],[-231,801],[10,133],[-123,190],[-215,483],[-38,469],[-148,315],[61,477],[-10,494],[-89,441],[109,543],[34,523],[33,522],[-50,773],[-88,492],[-80,268],[33,112],[402,-195],[148,-544],[69,152],[-45,472],[-94,473]],[[6833,63393],[49,-50],[45,-77],[71,-202],[-7,-32],[-108,-123],[-89,-90],[-41,-96],[-69,82],[8,161],[-46,210],[14,64],[48,94],[-19,113],[16,54],[21,-11],[107,-97]],[[6668,63787],[-23,-69],[-94,-41],[-47,121],[-32,47],[-3,36],[27,49],[99,-55],[73,-88]],[[6456,64025],[-9,-63],[-149,17],[21,70],[137,-24]],[[6104,64336],[23,-37],[80,-191],[-15,-33],[-19,8],[-97,20],[-35,130],[-11,23],[74,80]],[[5732,64622],[5,-134],[-33,-57],[-93,105],[14,42],[43,57],[64,-13]],[[3759,86603],[220,-52],[27,-221],[-171,-89],[-182,107],[-168,157],[274,98]],[[7436,85213],[185,-39],[117,-179],[-240,-274],[-277,-219],[-142,148],[-43,270],[252,205],[148,88]],[[2297,88560],[171,-109],[173,59],[225,-152],[276,-77],[-23,-63],[-211,-121],[-211,125],[-106,104],[-245,-33],[-66,51],[17,216]],[[74266,80171],[-212,-383],[-230,-54],[-13,-577],[-155,-261],[-551,190],[-200,-1031],[-143,-128],[-550,-231],[250,-1e3],[-190,-150],[22,-328]],[[72294,76218],[-171,84],[-140,207],[-412,61],[-461,15],[-100,-63],[-396,242],[-158,-119],[-43,-340],[-457,198],[-183,-81],[-62,-252]],[[69711,76170],[-159,-107],[-367,-401],[-121,-412],[-104,-4],[-76,273],[-353,18],[-57,472],[-135,4],[21,578],[-333,421],[-476,-45],[-326,-84],[-265,519],[-227,218],[-431,412],[-52,50],[-715,-340],[11,-2124]],[[65546,75618],[-142,-28],[-195,452],[-188,161],[-315,-120],[-123,-191]],[[64583,75892],[-15,140],[68,240],[-53,201],[-322,196],[-125,517],[-154,146],[-9,187],[270,-54],[11,421],[236,93],[243,-86],[50,562],[-50,356],[-278,-28],[-236,141],[-321,-253],[-259,-121]],[[63639,78550],[-142,93],[29,296],[-177,385],[-207,-16],[-235,391],[160,436],[-81,118],[222,632],[285,-334],[35,421],[573,626],[434,15],[612,-399],[329,-233],[295,243],[440,12],[356,-298],[80,170],[391,-24],[69,272],[-450,396],[267,281],[-52,157],[266,150],[-200,394],[127,197],[1039,200],[136,142],[695,213],[250,239],[499,-124],[88,-597],[290,140],[356,-197],[-23,-314],[267,33],[696,543],[-102,-180],[355,-445],[620,-1463],[148,302],[383,-332],[399,148],[154,-104],[133,-332],[194,-112],[119,-244],[358,77],[147,-353]],[[69711,76170],[83,-57],[-234,-373],[205,-217],[198,144],[329,-304],[-355,-414],[-212,56]],[[69725,75005],[-114,-15],[-40,161],[58,267],[-371,-134],[-89,-370],[-132,-318],[-232,27],[-72,-254],[204,-137],[60,-429],[-156,-583]],[[68841,73220],[-210,122],[-154,4]],[[68477,73346],[7,352],[-369,247],[-291,282],[-181,271],[-317,398],[-137,593],[-93,105],[-301,-27],[-106,118],[-30,460],[-374,304],[-234,-334],[-237,-199],[45,-290],[-313,-8]],[[89166,50332],[482,-397],[513,-329],[192,-295],[154,-290],[43,-339],[462,-356],[68,-306],[-256,-62],[62,-383],[248,-378],[180,-611],[159,19],[-11,-255],[215,-98],[-84,-108],[295,-243],[-30,-166],[-184,-40],[-69,149],[-238,65],[-281,86],[-216,368],[-158,316],[-144,504],[-362,252],[-235,-164],[-170,-190],[35,-425],[-218,-198],[-155,96],[-288,25]],[[89175,46579],[-4,1876],[-5,1877]],[[92399,49722],[106,-185],[33,-299],[-87,-154],[-52,340],[-65,223],[-126,189],[-158,245],[-200,170],[77,139],[150,-162],[94,-126],[117,-139],[111,-241]],[[92027,48466],[-152,-140],[-142,-135],[-148,1],[-228,167],[-158,161],[23,178],[249,-84],[152,45],[42,276],[40,14],[27,-306],[158,44],[78,197],[155,206],[-30,339],[166,11],[56,-94],[-5,-320],[-93,-351],[-146,-48],[-44,-161]],[[92988,48754],[84,-130],[135,-366],[131,-195],[-39,-161],[-78,-58],[-120,221],[-122,366],[-59,439],[38,55],[30,-171]],[[89175,46579],[-247,472],[-282,116],[-69,-164],[-352,-18],[118,469],[175,160],[-72,626],[-134,483],[-538,488],[-229,48],[-417,532],[-82,-279],[-107,-51],[-63,211],[-1,250],[-212,283],[299,207],[198,-11],[-23,153],[-407,1],[-110,343],[-248,106],[-117,285],[374,140],[142,188],[446,-237],[44,-214],[78,-931],[287,-345],[232,611],[319,347],[247,1],[238,-201],[206,-206],[298,-110]],[[84713,46708],[28,-113],[5,-175]],[[84746,46420],[-181,-430],[-238,-127],[-33,69],[25,196],[119,351],[275,229]],[[87280,47858],[-27,434],[49,207],[58,195],[63,-169],[0,-274],[-143,-393]],[[82744,54212],[-158,-520],[204,-545],[-48,-265],[312,-533],[-329,-68],[-93,-393],[12,-522],[-267,-393],[-7,-574],[-107,-881],[-41,205],[-316,-259],[-110,352],[-198,33],[-139,184],[-330,-207],[-101,279],[-182,-32],[-229,67],[-43,772],[-138,160],[-134,493],[-38,504],[32,533],[165,383]],[[80461,52985],[47,-385],[190,-325],[179,117],[177,-42],[162,291],[133,51],[263,-162],[226,123],[143,801],[107,200],[96,655],[319,0],[241,-97]],[[85936,50216],[305,-168],[101,-441],[-234,238],[-232,48],[-157,-38],[-192,20],[65,317],[344,24]],[[85242,49646],[-192,106],[-54,248],[281,27],[69,-190],[-104,-191]],[[85536,53082],[20,-315],[164,-50],[26,-236],[-15,-503],[-143,57],[-42,-351],[114,-304],[-78,-69],[-112,365],[-82,736],[56,460],[92,210]],[[84146,52333],[319,24],[275,419],[48,-129],[-223,-571],[-209,-111],[-267,113],[-463,-29],[-243,-83],[-39,-436],[248,-512],[150,261],[518,196],[-22,-265],[-121,83],[-121,-337],[-245,-223],[263,-738],[-50,-198],[249,-665],[-2,-378],[-148,-170],[-109,203],[134,471],[-273,-222],[-69,159],[36,222],[-200,338],[21,561],[-186,-175],[24,-671],[11,-824],[-176,-84],[-119,169],[79,530],[-43,556],[-117,4],[-86,395],[115,377],[40,457],[139,868],[58,238],[237,427],[217,-170],[350,-80]],[[83414,45922],[-368,403],[259,113],[146,-175],[97,-175],[-17,-155],[-117,-11]],[[83705,46913],[185,44],[249,211],[-41,-320],[-417,-163],[-370,71],[0,210],[220,120],[174,-173]],[[82849,47014],[172,47],[69,-245],[-321,-116],[-193,-77],[-149,4],[95,332],[153,5],[74,203],[100,-153]],[[80134,48131],[38,-205],[533,-57],[61,237],[515,-277],[101,-373],[417,-105],[341,-342],[-317,-220],[-306,232],[-251,-15],[-288,42],[-260,104],[-322,220],[-204,57],[-116,-72],[-506,237],[-48,247],[-255,43],[191,550],[337,-34],[224,-225],[115,-44]],[[78991,51205],[47,-402],[97,-321],[204,-51],[135,-365],[-70,-716],[-11,-891],[-308,-12],[-234,481],[-356,471],[-119,349],[-210,469],[-138,432],[-212,806],[-244,480],[-81,495],[-103,449],[-250,363],[-145,493],[-209,322],[-290,635],[-24,293],[178,-23],[430,-111],[246,-564],[215,-390],[153,-240],[263,-619],[283,-9],[233,-394],[161,-482],[211,-263],[-111,-471],[159,-200],[100,-14]],[[30935,21517],[106,-267],[139,-432],[361,-345],[389,-144],[-125,-288],[-264,-29],[-141,203]],[[31400,20215],[-168,16],[-297,0],[0,1286]],[[33993,34428],[-70,-461],[-74,-592],[3,-573],[-61,-128],[-21,-372]],[[33770,32302],[-19,-301],[353,-493],[-38,-397],[173,-251],[-14,-282],[-267,-738],[-412,-309],[-557,-120],[-305,58],[59,-343],[-57,-431],[51,-291],[-167,-202],[-284,-80],[-267,210],[-108,-151],[39,-572],[188,-173],[152,181],[82,-299],[-255,-179],[-223,-358],[-41,-579],[-66,-309],[-262,-1],[-218,-295],[-80,-432],[273,-422],[266,-116],[-96,-517],[-328,-325],[-180,-675],[-254,-227],[-113,-270],[89,-598],[185,-333],[-117,29]],[[30952,21711],[-257,90],[-672,77],[-115,336],[6,431],[-185,-37],[-98,209],[-24,611],[213,253],[88,365],[-33,292],[148,491],[101,763],[-30,338],[122,109],[-30,217],[-129,115],[92,242],[-126,218],[-65,665],[112,117],[-47,702],[65,590],[75,513],[166,209],[-84,563],[-1,529],[210,376],[-7,481],[159,562],[1,530],[-72,105],[-128,994],[171,592],[-27,558],[100,523],[182,540],[196,358],[-83,226],[58,186],[-9,960],[302,284],[96,598],[-34,144]],[[31359,38736],[231,521],[364,-141],[163,-416],[109,464],[316,-24],[45,-123]],[[32587,39017],[511,-940],[227,-88],[339,-425],[286,-225],[40,-254],[-273,-876],[280,-156],[312,-88],[220,92],[252,441],[45,509]],[[34826,37007],[138,110],[139,-332],[-6,-460],[-234,-318],[-186,-234],[-314,-559],[-370,-786]],[[31400,20215],[-92,-233],[-238,-178],[-137,18],[-164,46],[-202,174],[-291,83],[-350,322],[-283,309],[-383,645],[229,-121],[390,-384],[369,-207],[143,264],[90,394],[256,238],[198,-68]],[[30952,21711],[-247,4],[-134,-141],[-250,-208],[-45,-538],[-118,-14],[-313,188],[-318,401],[0,0],[-346,329],[-87,365],[79,337],[-140,383],[-36,982],[119,554],[293,445],[-422,168],[265,509],[94,956],[309,-202],[145,1193],[-186,153],[-87,-719],[-175,81],[87,823],[95,1067],[127,394],[-80,562],[-22,649],[117,18],[170,930],[192,922],[118,858],[-64,863],[83,475],[-34,711],[163,703],[50,1114],[89,1196],[87,1287],[-20,943],[-58,811]],[[30452,41263],[143,147],[74,295]],[[30669,41705],[136,-391],[37,-416],[146,-244],[-88,-557],[150,-646],[109,-794],[200,79]],[[58538,47026],[-109,59],[-373,-97],[-75,-69],[-79,-368],[62,-254],[-49,-681],[-34,-578],[75,-103],[194,-224],[76,105],[23,-621],[-212,4],[-114,317],[-103,246],[-213,80],[-62,302],[-170,-182],[-222,81],[-93,261],[-176,53],[-131,-14],[-15,179],[-96,15]],[[56642,45537],[-127,34],[-172,-87],[-121,15],[-68,-53],[15,685],[-93,214],[-21,354],[41,347],[-56,222],[-5,363],[-337,-5],[24,207],[-142,-2],[-15,-100],[-172,-22],[-69,-336],[-42,-144],[-154,81],[-91,-81],[-184,-46],[-106,301],[-64,186],[-80,345],[-68,430],[-820,7],[-98,-69],[-80,11],[-115,-78]],[[53422,48316],[-39,179]],[[53383,48495],[71,61],[9,251],[45,148],[101,121]],[[53609,49076],[73,-59],[95,221],[152,-6],[17,-163],[104,-102],[164,361],[161,281],[71,185],[-10,473],[121,560],[127,296],[183,278],[32,184],[7,211],[45,200],[-14,326],[34,510],[55,360],[83,308],[16,347]],[[55125,53847],[25,402],[108,292],[149,186],[229,-196],[177,-212],[203,-57],[207,-112],[83,347],[38,45],[127,-58],[309,287],[110,-121],[90,17],[41,140],[104,49],[209,-60],[178,-14],[91,61]],[[57603,54843],[169,-475],[124,-70],[75,97],[128,-38],[155,122],[66,-246],[244,-383]],[[58564,53850],[0,0],[-16,-673],[111,-78],[-89,-205],[-107,-153],[-106,-300],[-59,-268],[-15,-462],[-65,-220],[-2,-434]],[[58216,51057],[-80,-161],[-10,-342],[-38,-45],[-26,-315]],[[58062,50194],[70,-262],[17,-694]],[[61551,50860],[-165,475],[-3,2098],[243,653]],[[61626,54086],[76,182],[178,10],[247,406],[362,26],[785,1728]],[[63274,56438],[194,481],[125,353],[0,301],[0,581],[1,237],[2,9],[0,0]],[[63596,58400],[89,12],[128,85],[147,58],[132,198],[105,1],[6,-159],[-25,-335],[1,-303],[-59,-208],[-78,-622],[-134,-644],[-172,-735],[-238,-844],[-237,-645],[-327,-785],[-278,-467],[-415,-571],[-259,-438],[-304,-698],[-64,-304],[-63,-136]],[[59417,51282],[-3,611],[80,233],[137,381],[101,420],[-123,661],[-32,289],[-132,400]],[[59445,54277],[171,344],[188,379]],[[59804,55e3],[145,-96],[0,-324],[95,-189],[193,0],[352,-489],[87,-6],[65,16],[62,-67],[185,-45],[82,240],[254,241],[112,-195],[190,0]],[[61551,50860],[-195,-230],[-68,-240],[-104,-42],[-40,-406],[-89,-233],[-54,-383],[-112,-190]],[[56824,56568],[-212,252],[-96,166],[-18,179],[45,240],[-1,235],[-160,360],[-31,246]],[[56351,58246],[3,140],[-102,169],[-3,335],[-58,222],[-98,-33],[28,211],[72,240],[-32,239],[92,176],[-58,135],[73,355],[127,425],[240,-41],[-14,2286]],[[56621,63105],[3,242],[320,2],[0,1150]],[[56944,64499],[1117,0],[1077,0],[1102,0]],[[60240,64499],[90,-565],[-61,-105],[40,-593],[102,-687],[106,-142],[152,-213]],[[60669,62194],[-141,-328],[-204,-95],[-88,-177],[-27,-382],[-120,-847],[30,-230]],[[60119,60135],[-45,-495],[-112,-567],[-168,-285],[-119,-440],[-28,-236],[-132,-161],[-82,-603],[1,-68]],[[59434,57280],[-39,11],[5,287],[-33,197],[-143,228],[-34,415],[34,425],[-129,40],[-19,-129],[-167,-29],[67,-169],[23,-346],[-152,-316],[-138,-415],[-144,-59],[-233,336],[-105,-119],[-29,-168],[-143,-109],[-9,-118],[-277,0],[-38,118],[-200,20],[-100,-99],[-77,50],[-143,336],[-48,158],[-200,-79],[-76,-267],[-72,-514],[-95,-109],[-85,-63],[189,-225]],[[56351,58246],[-176,-98],[-141,-233],[-201,-629],[-261,-266],[-269,35],[-78,-53],[28,-202],[-145,-202],[-118,-224],[-350,-221],[-69,131],[-46,11],[-52,-148],[-229,-44]],[[54244,56103],[43,156],[-87,397],[-39,239],[-121,98],[-164,336],[60,271],[127,-57],[78,41],[155,-6],[-151,523],[10,383],[-18,382],[-111,369]],[[54026,59235],[28,271],[-178,13],[0,371],[-115,213],[120,759],[354,543],[15,749],[107,1168],[60,248],[-116,198],[-4,183],[-104,150],[-68,895]],[[54125,64996],[280,315],[1108,-1103],[1108,-1103]],[[30080,63183],[24,-314],[-21,-222],[-68,-97],[71,-172],[-5,-157]],[[30081,62221],[-185,98],[-131,-40],[-169,42],[-130,-108],[-149,179],[24,186],[256,-80],[210,-46],[100,128],[-127,250],[2,220],[-175,89],[62,159],[170,-25],[241,-90]],[[30080,63183],[34,98],[217,-3],[165,-148],[73,14],[50,-204],[152,11],[-9,-171],[124,-21],[136,-211],[-103,-235],[-132,126],[-127,-25],[-92,28],[-50,-105],[-106,-36],[-43,140],[-92,-83],[-111,-394],[-71,92],[-14,165]],[[63639,78550],[-127,-342],[-269,-95],[-276,-594],[252,-547],[-27,-388],[303,-678],[0,0]],[[63495,75906],[-166,-232],[-48,-146],[-122,39],[-191,350],[-78,19]],[[62890,75936],[-175,134],[-85,236],[-259,120],[-169,-90],[-48,107],[-378,276],[-409,93],[-235,99],[-34,-68]],[[61098,76843],[-354,486],[-317,218],[-240,338],[202,92],[231,482],[-156,227],[410,236],[-8,125],[-249,-92]],[[60617,78955],[9,255],[143,161],[269,42],[44,192],[-62,318],[113,302],[-3,169],[-410,187],[-162,-6],[-172,270],[-213,-92],[-352,203],[6,113],[-99,250],[-222,28],[-23,178],[70,117],[-178,326],[-288,-56],[-84,29],[-70,-131],[-104,24]],[[58829,81834],[0,0],[-68,368],[-66,192],[54,53],[224,-20],[108,126],[-80,154],[-187,101],[16,104],[-113,105],[-174,377],[60,156],[-27,270],[-272,137],[-146,-68],[-39,143],[-293,144]],[[57826,84176],[-89,340],[-24,279],[-134,133]],[[57579,84928],[120,183],[-83,537],[198,332],[-42,100],[0,0]],[[57772,86080],[316,318],[-291,274]],[[57797,86672],[0,0],[594,735],[258,333],[105,294],[-411,394],[113,375],[-250,429],[187,494],[-323,655],[256,435],[-425,383],[41,403]],[[57942,91602],[224,54],[473,231]],[[58639,91887],[0,0],[286,200],[456,-348],[761,-137],[1050,-652],[213,-273],[18,-384],[-308,-302],[-454,-154],[-1240,438],[-204,-73],[453,-422],[18,-267],[18,-589],[358,-175],[217,-150],[36,279],[-168,248],[177,218],[672,-358],[233,140],[-186,422],[647,564],[256,-33],[260,-202],[161,396],[-231,343],[136,345],[-204,357],[777,-185],[158,-322],[-351,-71],[1,-321],[219,-197],[429,125],[68,367],[580,274],[970,495],[209,-28],[-273,-350],[344,-60],[199,197],[521,16],[412,239],[317,-347],[315,381],[-291,334],[145,190],[820,-175],[385,-180],[1006,-658],[186,302],[-282,304],[-8,122],[-335,57],[92,273],[-149,449],[-8,185],[512,521],[183,523],[206,114],[736,-152],[57,-320],[-263,-468],[173,-183],[89,-403],[-63,-789],[307,-353],[-120,-384],[-544,-818],[318,-85],[110,207],[306,148],[74,285],[240,274],[-162,328],[130,380],[-304,47],[-67,321],[222,578],[-361,469],[497,389],[-64,409],[139,13],[145,-319],[-109,-556],[297,-105],[-127,415],[465,227],[577,30],[513,-328],[-247,479],[-28,614],[483,116],[669,-25],[602,75],[-226,301],[321,378],[319,16],[540,286],[734,77],[93,157],[729,54],[227,-129],[624,306],[510,-10],[77,249],[265,245],[656,236],[476,-186],[-378,-142],[629,-89],[75,-284],[254,140],[812,-8],[626,-281],[223,-215],[-69,-300],[-307,-170],[-730,-320],[-209,-171],[345,-80],[410,-146],[251,109],[141,-369],[122,149],[444,91],[892,-95],[67,-269],[1162,-86],[15,440],[590,-101],[443,3],[449,-303],[128,-369],[-165,-241],[349,-453],[437,-234],[268,605],[446,-260],[473,155],[538,-177],[204,162],[455,-81],[-201,534],[367,250],[2509,-374],[236,-342],[727,-440],[1122,109],[553,-95],[231,-238],[-33,-421],[342,-164],[372,118],[492,15],[525,-113],[526,64],[484,-512],[344,184],[-224,368],[123,256],[886,-161],[578,34],[799,-275],[389,-251],[0,-2294],[-2,-3],[-357,-253],[-360,42],[250,-307],[166,-474],[128,-155],[32,-238],[-71,-153],[-518,126],[-777,-434],[-247,-67],[-425,-405],[-403,-353],[-102,-262],[-397,399],[-724,-453],[-126,214],[-268,-246],[-371,79],[-90,-379],[-333,-557],[10,-233],[316,-129],[-37,-839],[-258,-21],[-119,-482],[116,-248],[-486,-294],[-96,-657],[-415,-141],[-83,-585],[-400,-536],[-103,396],[-119,841],[-155,1279],[134,799],[234,344],[14,269],[432,129],[496,725],[479,592],[499,459],[223,812],[-337,-49],[-167,-474],[-705,-632],[-227,708],[-717,-196],[-696,-965],[230,-353],[-620,-151],[-430,-59],[20,417],[-431,87],[-344,-283],[-850,99],[-914,-171],[-899,-1124],[-1065,-1358],[438,-73],[136,-360],[270,-128],[178,288],[305,-38],[401,-633],[9,-490],[-217,-576],[-23,-687],[-126,-921],[-418,-833],[-94,-399],[-377,-670],[-374,-665],[-179,-340],[-370,-338],[-175,-8],[-175,280],[-373,-421],[-43,-192]],[[86327,76143],[-39,101],[0,0]],[[86288,76244],[-2,292],[142,16],[40,680],[-73,494],[238,203],[338,-102],[186,560],[96,631],[107,211],[146,518],[-459,-170],[-240,-227],[-423,1],[-112,541],[-329,409],[-483,184],[-103,564],[-97,354],[-104,248],[-172,581],[-244,212],[-415,171],[-369,-15],[-345,-104],[-229,-287],[152,-137],[4,-318],[-155,-184],[-251,-611],[3,-253],[-392,-364],[-333,217]],[[82410,80559],[-331,-48],[-146,193],[-166,62],[-407,-405],[-366,-96],[-255,-143],[-350,94],[-258,-6],[-168,295],[-272,276],[-279,76],[-351,-75],[-263,-107],[-394,242],[-53,432],[-327,148],[-252,67],[-311,238],[-288,-596],[113,-339],[-270,-401],[-402,144],[-277,21],[-186,269],[-289,9],[-242,176],[-423,-271],[-530,-496],[-292,-99]],[[74375,80219],[-109,-48]],[[99645,92774],[354,240],[0,-394],[-305,-29],[-49,183]],[[76049,98490],[600,130],[540,-290],[640,-557],[-69,-518],[-606,-71],[-773,166],[-462,220],[-213,413],[-379,113],[722,394]],[[78565,97486],[704,-327],[-82,-234],[-1566,-222],[507,756],[229,64],[208,-37]],[[88563,95675],[734,-25],[1004,-306],[-219,-427],[-1023,16],[-461,-136],[-550,374],[149,396],[366,108]],[[91172,95220],[697,-151],[-321,-228],[-444,52],[-516,227],[66,187],[518,-87]],[[88850,94082],[263,227],[348,54],[394,-221],[34,-151],[-421,-4],[-569,64],[-49,31]],[[62457,98239],[542,105],[422,7],[57,-155],[159,138],[262,95],[412,-126],[-107,-88],[-373,-76],[-250,-44],[-39,-94],[-324,-95],[-301,136],[158,180],[-618,17]],[[56314,83116],[-511,-9],[-342,65]],[[55461,83172],[63,254],[383,186]],[[55907,83612],[291,-100],[123,-92],[-30,-157],[23,-147]],[[64863,94300],[665,506],[-75,261],[621,304],[917,370],[925,108],[475,214],[541,74],[193,-227],[-187,-179],[-984,-286],[-848,-274],[-863,-548],[-414,-563],[-435,-553],[56,-479],[531,-472],[-164,-51],[-907,75],[-74,256],[-503,154],[-40,311],[284,124],[-10,314],[551,491],[-255,70]],[[89698,82757],[96,-555],[-7,-567],[114,-581],[280,-1020],[-411,190],[-171,-832],[271,-590],[-8,-403],[-211,347],[-182,-445],[-51,483],[31,561],[-32,621],[64,436],[13,770],[-163,566],[24,787],[257,265],[-110,267],[123,81],[73,-381]],[[1409,90532],[-24,-358],[187,-143],[-64,418],[754,-86],[544,-539],[-276,-251],[-455,-59],[-7,-563],[-111,-120],[-260,17],[-212,201],[-369,168],[-62,250],[-283,94],[-315,-74],[-151,201],[60,214],[-333,-137],[126,-271],[-158,-244],[0,2294],[681,-440],[728,-572]],[[363,92655],[-363,-35],[0,394],[36,24],[235,-1],[402,-165],[-24,-79],[-286,-138]],[[59287,78304],[73,142],[198,-123],[89,-23],[36,-114],[42,-17]],[[59725,78169],[2,-50],[136,-139],[284,35],[-55,-206],[-304,-100],[-377,-333],[-154,117],[61,271],[-304,169],[50,110],[265,191],[-42,70]],[[28061,67257],[130,46],[184,-17],[8,-150],[-303,-92],[-19,213]],[[28391,67401],[220,-259],[-48,-409],[-51,73],[4,301],[-124,228],[-1,66]],[[28280,66347],[84,-23],[97,-478],[1,-334],[-68,-29],[-70,332],[-104,167],[60,365]],[[33e3,21970],[333,345],[236,-144],[167,231],[222,-259],[-83,-202],[-375,-173],[-125,202],[-236,-259],[-139,259]],[[57942,91602],[117,405],[-356,229],[-431,-196],[-137,-422],[-265,-255],[-298,140],[-362,-29],[-309,304],[-167,-152]],[[55734,91626],[-172,-23],[-41,-379],[-523,92],[-74,-321],[-267,2],[-183,-409],[-278,-639],[-431,-810],[101,-197],[-97,-228],[-275,10],[-180,-540],[17,-765],[177,-292],[-92,-677],[-231,-395],[-122,-332]],[[53063,85723],[-187,354],[-548,-666],[-371,-135],[-384,293],[-99,619],[-88,1329],[256,371],[733,483],[549,595],[508,802],[668,1112],[465,434],[763,722],[610,252],[457,-31],[423,477],[506,-25],[499,115],[869,-422],[-358,-154],[305,-361]],[[54206,97712],[105,197],[408,20],[350,-201],[915,-429],[-699,-227],[-155,-424],[-243,-108],[-132,-478],[-335,-22],[-598,351],[252,205],[-416,166],[-541,487],[-216,451],[757,206],[152,-202],[396,8]],[[57613,97932],[-412,-310],[-806,-68],[-819,96],[-50,159],[-398,10],[-304,264],[858,161],[403,-138],[281,172],[702,-144],[545,-202]],[[56867,96664],[-620,-236],[-490,134],[191,149],[-167,184],[575,115],[110,-216],[401,-130]],[[37010,99413],[932,344],[975,-26],[354,213],[982,55],[2219,-72],[1737,-457],[-513,-222],[-1062,-25],[-1496,-56],[140,-103],[984,63],[836,-198],[540,176],[231,-206],[-305,-335],[707,214],[1348,223],[833,-111],[156,-246],[-1132,-410],[-157,-133],[-888,-99],[643,-28],[-324,-420],[-224,-373],[9,-641],[333,-376],[-434,-24],[-457,-182],[513,-305],[65,-490],[-297,-53],[360,-495],[-617,-42],[322,-234],[-91,-203],[-391,-89],[-388,-2],[348,-390],[4,-256],[-549,238],[-143,-154],[375,-144],[364,-352],[105,-464],[-495,-111],[-214,222],[-344,331],[95,-391],[-322,-303],[732,-24],[383,-31],[-745,-502],[-755,-454],[-813,-199],[-306,-2],[-288,-222],[-386,-608],[-597,-404],[-192,-23],[-370,-142],[-399,-134],[-238,-357],[-4,-403],[-141,-378],[-453,-461],[112,-450],[-125,-476],[-142,-563],[-391,-35],[-410,471],[-556,3],[-269,315],[-186,563],[-481,716],[-141,375],[-38,517],[-384,532],[100,424],[-186,203],[275,673],[418,214],[110,241],[58,450],[-318,-204],[-151,-85],[-249,-83],[-341,188],[-19,392],[109,306],[258,8],[567,-153],[-478,366],[-249,197],[-276,-81],[-232,143],[310,536],[-169,215],[-220,398],[-335,611],[-353,223],[3,241],[-745,337],[-590,42],[-743,-23],[-677,-42],[-323,183],[-482,362],[729,181],[559,31],[-1188,149],[-627,236],[39,223],[1051,277],[1018,277],[107,210],[-750,206],[243,230],[961,402],[404,62],[-115,258],[658,152],[854,90],[853,6],[303,-180],[737,317],[663,-215],[390,-45],[577,-188],[-660,311],[38,246]],[[69148,23827],[179,-181],[263,-72],[9,-110],[-77,-262],[-427,-37],[-7,306],[41,238],[19,118]],[[84713,46708],[32,136],[239,129],[194,20],[87,72],[105,-72],[-102,-156],[-289,-252],[-233,-165]],[[54540,35373],[133,284],[109,-157],[47,-247],[125,-42],[175,-108],[149,42],[248,294],[0,2127]],[[55526,37566],[75,-86],[165,-548],[-26,-351],[62,-202],[199,59],[139,257],[132,173],[68,276],[135,134],[117,-70],[133,-162],[226,-28],[178,134],[28,180],[48,275],[152,46],[83,217],[93,383],[249,430],[393,424]],[[58175,39107],[113,-6],[134,-97],[94,69],[148,-58]],[[58664,39015],[133,-810],[72,-410],[-49,-642],[23,-206]],[[58843,36947],[-140,105],[-80,-41],[-26,-168],[-76,-216],[2,-199],[166,-312],[163,62],[56,256]],[[58908,36434],[211,-5]],[[59119,36429],[-70,-419],[-32,-479],[-72,-260],[-190,-290],[-54,-84],[-118,-292],[-77,-296],[-158,-413],[-314,-594],[-196,-345],[-210,-262],[-290,-224],[-141,-30],[-36,-160],[-169,85],[-138,-109],[-301,111],[-168,-71],[-115,31],[-286,-228],[-238,-91],[-171,-218],[-127,-13],[-117,205],[-94,10],[-120,258],[-13,-80],[-37,155],[2,337],[-90,386],[89,105],[-7,442],[-182,539],[-139,488],[-1,1],[-199,749]],[[58049,35154],[-121,178],[-130,-118],[-151,-225],[-148,-365],[209,-443],[99,58],[51,184],[155,90],[47,187],[85,281],[-96,173]],[[22908,66710],[108,17],[-107,-505],[-49,-415],[-20,-771],[-27,-281],[48,-315],[86,-280],[56,-447],[184,-429],[65,-328],[109,-284],[295,-153],[114,-241],[244,161],[212,58],[208,104],[175,99],[176,235],[67,336],[22,483],[48,169],[188,151],[294,133],[246,-20],[169,49],[66,-122],[-9,-278],[-149,-342],[-66,-351],[51,-100],[-42,-249],[-69,-449],[-71,148],[-58,-10]],[[25472,62483],[-53,-7],[-99,-348],[-51,68],[-33,-26],[2,-85]],[[25238,62085],[-257,6],[-259,-1],[-1,-324],[-125,-1],[103,-193],[103,-133],[31,-124],[45,-35],[-7,-197],[-357,-1],[-133,-470],[39,-107],[-32,-135],[-7,-168]],[[24381,60202],[-314,620],[-144,187],[-226,150],[-156,-42],[-223,-216],[-140,-57],[-196,152],[-208,109],[-260,264],[-208,81],[-314,268],[-233,275],[-70,154],[-155,34],[-284,183],[-116,262],[-299,327],[-139,363],[-66,281],[93,56],[-29,164],[64,150],[1,199],[-93,259],[-25,229],[-94,290],[-244,573],[-280,450],[-135,359],[-238,235],[-51,140],[42,356],[-142,135],[-164,279],[-69,402],[-149,47],[-162,303],[-130,281],[-12,180],[-149,434],[-99,441],[5,221],[-201,229],[-93,-26],[-159,159],[-44,-234],[46,-276],[27,-433],[95,-237],[206,-397],[46,-135],[42,-41],[37,-198],[49,8],[56,-372],[85,-146],[59,-204],[174,-293],[92,-536],[83,-252],[77,-270],[15,-304],[134,-19],[112,-261],[100,-257],[-6,-104],[-117,-211],[-49,3],[-74,350],[-181,328],[-201,278],[-142,147],[9,421],[-42,312],[-132,179],[-191,257],[-37,-75],[-70,151],[-171,139],[-164,334],[20,44],[115,-33],[103,215],[10,260],[-214,411],[-163,159],[-102,360],[-103,377],[-129,461],[-113,518]],[[33993,34428],[180,62],[279,-446],[103,17],[286,-369],[218,-318],[160,-392],[-122,-273],[77,-326]],[[35174,32383],[-121,-362],[-313,-320],[-205,115],[-151,-62],[-256,247],[-189,-18],[-169,319]],[[34826,37007],[54,332],[38,340],[0,317],[-100,105],[-104,-94],[-103,26],[-33,222],[-26,527],[-52,172],[-187,156],[-114,-113],[-293,111],[18,782],[-82,320]],[[33842,40210],[87,119],[-27,328],[77,253],[49,453],[-66,358],[-151,162],[-30,227],[41,333],[-533,23],[-107,671],[81,10],[-3,248],[-55,168],[-12,333],[-161,171],[-175,-6],[-115,167],[-188,114],[-109,216],[-311,95],[-302,516],[23,386],[-34,221],[29,432],[-363,-98],[-147,-216],[-243,-234],[-62,-174],[-143,-12],[-206,48]],[[30686,45522],[-157,-99],[-126,66],[18,875],[-228,-339],[-245,15],[-105,307],[-184,33],[59,247],[-155,351],[-115,518],[73,106],[0,243],[168,166],[-28,312],[71,200],[20,269],[318,392],[227,111],[37,86],[251,-27]],[[30585,49354],[125,1579],[6,250],[-43,330],[-123,210],[1,418],[156,95],[56,-60],[9,221],[-162,60],[-4,360],[541,-13],[92,198],[77,-182],[55,-340],[52,71]],[[31423,52551],[153,-304],[216,37],[54,176],[206,135],[115,94],[32,244],[198,164],[-15,121],[-235,49],[-39,363],[12,386],[-125,149],[52,53],[206,-73],[221,-144],[80,136],[200,89],[310,216],[102,220],[-37,162]],[[33129,54824],[145,26],[64,-133],[-36,-253],[96,-87],[63,-268],[-77,-203],[-44,-490],[71,-291],[20,-267],[171,-270],[137,-28],[30,112],[88,25],[126,101],[90,153],[154,-48],[67,20]],[[34294,52923],[151,-47],[25,118],[-46,114],[28,167],[112,-51],[131,59],[159,-122]],[[34854,53161],[121,-119],[86,156],[62,-24],[38,-162],[133,41],[107,219],[85,424],[164,527]],[[35650,54223],[95,27],[69,-318],[155,-1008],[149,-95],[7,-397],[-208,-474],[86,-174],[491,-90],[10,-578],[211,378],[349,-207],[462,-351],[135,-338],[-45,-319],[323,178],[540,-305],[415,23],[411,-477],[355,-645],[214,-166],[237,-23],[101,-182],[94,-733],[46,-348],[-110,-953],[-142,-376],[-391,-801],[-177,-651],[-206,-499],[-69,-11],[-78,-424],[20,-1079],[-77,-888],[-30,-379],[-88,-228],[-49,-769],[-282,-752],[-47,-595],[-225,-250],[-65,-345],[-302,2],[-437,-222],[-195,-256],[-311,-168],[-327,-459],[-235,-571],[-41,-430],[46,-318],[-51,-582],[-63,-281],[-195,-317],[-308,-1013],[-244,-457],[-189,-269],[-127,-548],[-183,-329]],[[30669,41705],[175,622],[-119,484],[63,194],[-49,213],[108,288],[6,490],[13,405],[60,195],[-240,926]],[[33842,40210],[-4,177],[-259,295],[-258,8],[-484,-167],[-133,-507],[-7,-310],[-110,-689]],[[30452,41263],[-279,331],[-24,236],[-551,578],[-498,630],[-214,355],[-115,476],[46,166],[-236,755],[-274,1063],[-262,1147],[-114,262],[-87,424],[-216,376],[-198,233],[90,257],[-134,550],[86,403],[221,364]],[[27693,49869],[33,-240],[-79,-137],[8,-211],[114,45],[113,-62],[116,-291],[157,237],[53,389],[170,501],[334,227],[303,603],[86,374],[-38,438]],[[29063,51742],[74,54],[184,-272],[89,-272],[129,-149],[163,-603],[207,-72],[153,152],[101,-100],[166,50],[213,-270],[-179,-586],[83,-14],[139,-306]],[[29063,51742],[-119,136],[-137,191],[-79,-92],[-235,80],[-68,248],[-52,-9],[-278,329]],[[28095,52625],[-37,178],[103,44],[-12,288],[65,209],[138,38],[117,362],[106,302],[-102,137],[52,335],[-62,526],[59,152],[-44,487],[-112,306]],[[28366,55989],[36,280],[89,-41],[52,171],[-64,339],[34,85]],[[28513,56823],[143,-19],[209,402],[114,62],[3,190],[51,487],[159,267],[175,11],[22,120],[218,-48],[218,291],[109,128],[134,278],[98,-36],[73,-151],[-54,-194]],[[30185,58611],[-178,-96],[-71,-288],[-107,-165],[-81,-215],[-34,-410],[-77,-337],[144,-39],[35,-265],[62,-126],[21,-232],[-33,-213],[10,-120],[69,-48],[66,-201],[357,55],[161,-73],[196,-496],[112,62],[200,-31],[158,66],[99,-99],[-50,-311],[-62,-193],[-22,-413],[56,-383],[79,-171],[9,-129],[-140,-286],[100,-127],[74,-202],[85,-574]],[[28366,55989],[-93,166],[-59,311],[68,154],[-70,40],[-52,190],[-138,160],[-122,-37],[-56,-200],[-112,-145],[-61,-20],[-27,-120],[132,-312],[-75,-74],[-40,-85],[-130,-29],[-48,344],[-36,-98],[-92,33],[-56,232],[-114,38],[-72,68],[-119,-1],[-8,-125],[-32,87]],[[26954,56566],[14,114],[23,117],[-10,104],[41,68],[-58,86],[-1,232],[107,51]],[[27070,57338],[100,-206],[-6,-122],[111,-26],[26,47],[77,-142],[136,42],[119,145],[168,116],[95,172],[153,-33],[-10,-57],[155,-20],[124,-99],[90,-173],[105,-159]],[[26954,56566],[-151,128],[-56,121],[32,100],[-11,127],[-77,138],[-109,113],[-95,74],[-19,168],[-73,103],[18,-167],[-55,-138],[-64,160],[-89,57],[-38,116],[2,175],[36,182],[-78,81],[64,111]],[[26191,58215],[42,74],[183,-152],[63,75],[89,-48],[46,-119],[82,-38],[66,122]],[[26762,58129],[70,-313],[108,-232],[130,-246]],[[26191,58215],[-96,181],[-130,233],[-61,194],[-117,181],[-140,260],[31,89],[46,-87],[21,41]],[[25745,59307],[86,24],[35,131],[41,5],[-6,283],[65,14],[58,-4],[60,154],[82,-117],[29,72],[51,68],[97,159],[4,118],[27,-5],[36,138],[29,17],[47,-88],[56,-26],[61,73],[70,0],[97,75],[38,79],[95,-12]],[[26903,60465],[-24,-55],[-14,-129],[29,-210],[-64,-197],[-30,-231],[-9,-254],[15,-148],[7,-260],[-43,-56],[-26,-247],[19,-152],[-56,-147],[12,-156],[43,-94]],[[25745,59307],[-48,180],[-84,50]],[[25613,59537],[19,231],[-38,62],[-57,41],[-122,-68],[-10,77],[-84,93],[-60,114],[-82,49]],[[25179,60136],[58,146],[-22,113],[20,111],[131,161],[127,220]],[[25493,60887],[29,-23],[61,101],[79,9],[26,-47],[43,28],[129,-52],[128,15],[90,64],[32,65],[89,-30],[66,-39],[73,13],[55,50],[127,-80],[44,-13],[85,-107],[80,-129],[101,-88],[73,-159]],[[25613,59537],[-31,-135],[-161,8],[-100,55],[-115,115],[-154,36],[-79,123]],[[24973,59739],[9,85],[95,145],[52,64],[-15,67],[65,36]],[[25238,62085],[-2,-457],[-22,-650],[83,1]],[[25297,60979],[90,-105],[24,86],[82,-73]],[[24973,59739],[-142,101],[-174,10],[-127,114],[-149,238]],[[25472,62483],[1,-84],[53,-3],[-5,-157],[-45,-249],[24,-89],[-29,-206],[18,-55],[-32,-291],[-55,-153],[-50,-18],[-55,-199]],[[30185,58611],[-8,-136],[-163,-67],[91,-262],[-3,-301],[-123,-334],[105,-457],[120,37],[62,417],[-86,202],[-14,436],[346,234],[-38,272],[97,181],[100,-404],[195,-10],[180,-321],[11,-190],[249,-6],[297,60],[159,-258],[213,-71],[155,180],[4,145],[344,34],[333,8],[-236,-170],[95,-272],[222,-43],[210,-283],[45,-462],[144,13],[109,-135]],[[33400,56648],[-220,-339],[-24,-210],[95,-213],[-69,-108],[-171,-93],[5,-265],[-75,-159],[188,-437]],[[33400,56648],[183,-212],[171,-375],[8,-297],[105,-13],[149,-281],[109,-201]],[[34125,55269],[-44,-518],[-169,-150],[15,-136],[-51,-297],[123,-418],[89,-1],[37,-325],[169,-501]],[[34125,55269],[333,-115],[30,104],[225,41],[298,-155]],[[35011,55144],[-144,-495],[22,-394],[109,-341],[-49,-248],[-24,-263],[-71,-242]],[[35011,55144],[95,-63],[204,-136],[294,-486],[46,-236]],[[51718,80315],[131,-151],[400,-106],[-140,-395],[-35,-410]],[[52074,79253],[-77,-98],[-126,53],[9,-147],[-203,-323],[-5,-261],[133,90],[95,-252]],[[51900,78315],[-11,-163],[82,-216],[-97,-176],[72,-445],[151,-73],[-32,-250]],[[52065,76992],[-252,-326],[-548,156],[-404,-186],[-32,-347]],[[50829,76289],[-322,-75],[-313,261],[-101,-125],[-511,262],[-111,224]],[[49471,76836],[144,345],[53,1147],[-287,605],[-205,291],[-424,222],[-28,420],[360,125],[466,-148],[-88,652],[263,-247],[646,449],[84,472],[243,116]],[[50698,81285],[40,-203],[129,-9],[129,-231],[194,-272],[143,45],[243,-263]],[[51576,80352],[62,-50],[80,13]],[[52429,76378],[179,220],[47,-494],[-92,-445],[-126,118],[-64,387],[56,214]],[[27693,49869],[148,430],[-60,251],[-106,-267],[-166,252],[56,163],[-47,522],[97,87],[52,359],[105,371],[-20,235],[153,123],[190,230]],[[31588,62492],[142,-51],[50,-114],[-71,-146],[-209,4],[-163,-21],[-16,247],[40,84],[227,-3]],[[28453,62478],[187,-52],[147,-138],[46,-158],[-195,-11],[-84,-96],[-156,92],[-159,210],[34,132],[116,40],[64,-19]],[[27147,65183],[240,-41],[219,-6],[261,-197],[110,-210],[260,65],[98,-136],[235,-356],[173,-260],[92,8],[165,-118],[-20,-162],[205,-23],[210,-236],[-33,-135],[-185,-73],[-187,-29],[-191,46],[-398,-56],[186,321],[-113,150],[-179,38],[-96,166],[-66,328],[-157,-22],[-259,154],[-83,121],[-362,89],[-97,113],[104,144],[-273,29],[-199,-299],[-115,-8],[-40,-141],[-138,-63],[-118,55],[146,178],[60,208],[126,128],[142,112],[210,55],[67,63]],[[58175,39107],[-177,261],[-215,88],[-82,365],[0,203],[-119,62],[-315,633],[-87,333],[-56,103],[-107,460]],[[57017,41615],[311,-63],[90,-66],[94,13],[154,373],[241,473],[100,46],[33,199],[159,230],[210,79]],[[58409,42899],[18,-215],[232,11],[128,-121],[60,-143],[132,-42],[145,-185],[0,-728],[-54,-400],[-12,-430],[45,-171],[-31,-339],[-42,-52],[-74,-415],[-292,-654]],[[55526,37566],[0,1681],[274,20],[8,2051],[207,19],[428,202],[106,-238],[177,226],[85,1],[156,130]],[[56967,41658],[50,-43]],[[54540,35373],[-207,435],[-108,420],[-62,561],[-68,417],[-93,887],[-7,689],[-35,314],[-108,237],[-144,476],[-146,691],[-60,361],[-226,563],[-17,441]],[[53259,41865],[134,110],[166,98],[180,-17],[166,-260],[42,40],[1126,25],[192,-276],[673,-82],[510,235]],[[56448,41738],[228,131],[180,-33],[109,-130],[2,-48]],[[45357,59658],[-115,449],[-138,205],[122,109],[134,404],[66,296]],[[45426,61121],[96,185],[138,-50],[135,126],[155,6],[133,-169],[184,-153],[168,-424],[184,-395]],[[46619,60247],[13,-358],[54,-330],[104,-162],[24,-223],[-13,-179]],[[46801,58995],[-40,-32],[-151,45],[-21,-64],[-61,-13],[-200,141],[-134,5]],[[46194,59077],[-513,25],[-75,-65],[-92,18],[-147,-93]],[[45367,58962],[-46,441]],[[45321,59403],[253,-12],[67,80],[50,5],[103,133],[119,-121],[121,-11],[120,130],[-56,166],[-92,-97],[-86,3],[-110,142],[-88,-10],[-63,-136],[-302,-17]],[[46619,60247],[93,105],[47,339],[88,13],[194,-160],[157,114],[107,-38],[42,128],[1114,8],[62,404],[-48,71],[-134,2485],[-134,2485],[425,11]],[[48632,66212],[937,-1257],[937,-1256],[66,-270],[173,-165],[129,-94],[3,-366],[308,56]],[[51185,62860],[1,-1326],[-152,-384],[-24,-355],[-247,-92],[-379,-49],[-102,-205],[-178,-22]],[[50104,60427],[-178,-3],[-70,110],[-153,-82],[-259,-238],[-53,-180],[-216,-259],[-38,-148],[-116,-117],[-134,78],[-76,-141],[-41,-395],[-221,-477],[7,-195],[-76,-244],[18,-334]],[[48498,57802],[-114,-86],[-65,-72],[-43,246],[-80,-65],[-48,11],[-51,-168],[-215,5],[-77,86],[-36,-52]],[[47769,57707],[-85,166],[15,172],[-35,67],[-59,-57],[11,187],[57,149],[-114,241],[-33,159],[-62,126],[-55,15],[-67,-80],[-90,-77],[-76,-125],[-119,46],[-77,146],[-46,20],[-73,-77],[-44,-1],[-16,211]],[[47587,67606],[1045,-1394]],[[45426,61121],[-24,311],[78,283],[34,543],[-30,569],[-34,286],[28,287],[-72,274],[-146,249]],[[50747,55434],[-229,-68]],[[50518,55366],[-69,398],[13,1322],[-56,119],[-11,283],[-96,201],[-85,170],[35,303]],[[50249,58162],[96,66],[56,251],[136,54],[61,172]],[[50598,58705],[93,169],[100,2],[212,-332]],[[51003,58544],[-11,-191],[62,-342],[-54,-232],[29,-154],[-135,-357],[-86,-176],[-52,-364],[7,-366],[-16,-928]],[[54026,59235],[-78,-33],[-9,-184]],[[53939,59018],[-52,-12],[-188,630],[-65,23],[-217,-322],[-215,168],[-150,34],[-80,-81],[-163,17],[-164,-245],[-141,-14],[-337,298],[-131,-142],[-142,10],[-104,218],[-279,214],[-298,-68],[-72,-124],[-39,-331],[-80,-233],[-19,-514]],[[50598,58705],[6,395],[-320,130],[-9,279],[-156,376],[-37,262],[22,280]],[[51185,62860],[392,257],[804,1132],[952,1097]],[[53333,65346],[439,-248],[156,-316],[197,214]],[[53939,59018],[110,-229],[-31,-104],[-14,-191],[-234,-446],[-74,-368],[-39,-299],[-59,-128],[-56,-403],[-148,-238],[-43,-291],[-63,-232],[-26,-239],[-191,-194],[-156,236],[-105,-9],[-165,-337],[-81,-5],[-132,-556],[-71,-408]],[[52361,54577],[-289,-207],[-105,30],[-107,-129],[-222,13],[-149,360],[-91,417],[-197,379],[-209,-7],[-245,1]],[[54244,56103],[-140,-583],[-67,-105],[-21,-446],[28,-243],[-23,-171],[132,-301],[23,-207],[103,-297],[127,-185],[12,-263],[29,-167]],[[54447,53135],[-20,-311],[-220,136],[-225,152],[-350,23]],[[53632,53135],[-35,31],[-164,-74],[-169,77],[-132,-38]],[[53132,53131],[-452,14]],[[52680,53145],[40,454],[-108,381],[-127,98],[-56,258],[-72,82],[4,159]],[[50518,55366],[-224,-122]],[[50294,55244],[-62,202],[-74,365],[-22,287],[61,518],[-69,210],[-27,454],[1,418],[-116,297],[20,180]],[[50006,58175],[243,-13]],[[50294,55244],[-436,-337],[-154,-198],[-250,-167],[-248,164]],[[49206,54706],[13,227],[-121,496],[73,650],[117,484],[-74,819]],[[49214,57382],[-38,434],[7,327],[482,27],[123,-42],[90,93],[128,-46]],[[48498,57802],[125,-126],[49,-190],[125,-122],[97,145],[130,22],[190,-149]],[[49206,54706],[-126,-6],[-194,112],[-178,-6],[-329,-101],[-193,-166],[-275,-211],[-54,15]],[[47857,54343],[22,474],[26,72],[-8,227],[-118,241],[-88,39],[-81,158],[60,256],[-28,278],[13,168]],[[47655,56256],[44,0],[17,251],[-22,112],[27,80],[103,69],[-69,461],[-64,238],[23,195],[55,45]],[[47655,56256],[-78,14],[-57,-232],[-78,3],[-55,123],[19,231],[-116,353],[-73,-65],[-59,-13]],[[47158,56670],[-77,-33],[3,211],[-44,151],[9,168],[-60,242],[-78,206],[-222,0],[-65,-108],[-76,-13],[-48,-125],[-32,-159],[-148,-254]],[[46320,56956],[-122,341],[-108,226],[-71,74],[-69,115],[-32,254],[-41,127],[-80,94]],[[45797,58187],[123,281],[84,-11],[73,97],[61,1],[44,76],[-24,191],[31,60],[5,195]],[[45797,58187],[-149,241],[-117,38],[-63,162],[1,88],[-84,122],[-18,124]],[[47857,54343],[-73,-5],[-286,274],[-252,439],[-237,315],[-187,371]],[[46822,55737],[66,184],[15,168],[126,313],[129,268]],[[46822,55737],[-75,43],[-200,232],[-144,308],[-49,211],[-34,425]],[[55125,53847],[-178,33],[-188,96],[-166,-305],[-146,-536]],[[56824,56568],[152,-232],[2,-188],[187,-299],[116,-250],[70,-345],[208,-228],[44,-183]],[[53609,49076],[-104,198],[-84,-97],[-112,-249]],[[53309,48928],[-228,610]],[[53081,49538],[212,318],[-105,381],[95,144],[187,71],[23,255],[148,-276],[245,-25],[85,273],[36,382],[-31,450],[-131,341],[120,667],[-69,114],[-207,-47],[-78,298],[21,251]],[[53081,49538],[-285,581],[-184,475],[-169,595],[9,192],[61,184],[67,419],[56,427]],[[52636,52411],[94,33],[404,-6],[-2,693]],[[52636,52411],[-52,87],[96,647]],[[59099,46514],[131,-257],[71,-489],[-47,-156],[-56,-467],[53,-477],[-87,-201],[-85,-535],[147,-149]],[[59226,43783],[-843,-474],[26,-410]],[[56448,41738],[-181,360],[-188,471],[13,1832],[579,-7],[-24,199],[41,216],[-49,270],[32,279],[-29,179]],[[59599,45195],[-77,-438],[77,-748],[97,8],[100,-185],[116,-417],[24,-740],[-120,-122],[-85,-399],[-181,356],[-21,405],[59,268],[-16,231],[-110,146],[-77,-53],[-159,276]],[[61198,45888],[0,0],[45,-258],[-11,-574],[34,-505],[11,-900],[49,-282],[-83,-412],[-108,-400],[-177,-357],[-254,-219],[-313,-279],[-313,-618],[-107,-106],[-194,-409],[-115,-133],[-23,-411],[132,-436],[54,-337],[4,-173],[49,29],[-8,-565],[-45,-267],[65,-99],[-41,-239],[-116,-205],[-229,-195],[-334,-312],[-122,-213],[24,-242],[71,-39],[-24,-303]],[[58908,36434],[-24,254],[-41,259]],[[53259,41865],[-26,363],[38,506],[96,527],[15,247],[90,519],[66,236],[159,377],[90,256],[29,427],[-15,326],[-83,206],[-74,350],[-68,345],[15,120],[85,228],[-84,557],[-57,385],[-139,364],[26,112]],[[53383,48495],[-74,433]],[[58062,50194],[169,-45],[85,328],[147,-38]],[[59922,70666],[-49,-182]],[[59873,70484],[-100,80],[-58,-383],[69,-65],[-71,-79],[-12,-152],[131,78]],[[59832,69963],[7,-224],[-139,-920]],[[59700,68819],[-27,149]],[[59673,68968],[-155,840],[0,0]],[[59518,69808],[0,0],[80,190],[-19,32],[74,270],[56,434],[40,146],[8,6]],[[59757,70886],[93,-1],[25,101],[75,7]],[[59950,70993],[4,-236],[-38,-87],[6,-4]],[[59757,70886],[99,469],[138,406],[5,20]],[[59999,71781],[125,-30],[45,-226],[-151,-217],[-68,-315]],[[63761,44648],[74,-245],[69,-380],[45,-693],[72,-269],[-28,-277],[-49,-169],[-94,338],[-53,-171],[53,-427],[-24,-244],[-77,-133],[-18,-488],[-109,-671],[-137,-793],[-172,-1092],[-106,-800],[-125,-668],[-226,-136],[-243,-244],[-160,147],[-220,206],[-77,304],[-18,510],[-98,460],[-26,414],[50,415],[128,100],[1,191],[133,437],[25,367],[-65,272],[-52,364],[-23,530],[97,322],[38,366],[138,21],[155,118],[103,104],[122,8],[158,328],[229,355],[83,289],[-38,247],[118,-70],[153,401],[6,346],[92,257],[96,-247]],[[59873,70484],[0,-352],[-41,-169]],[[45321,59403],[36,255]],[[52633,69283],[-118,1034],[-171,232],[-3,139],[-227,344],[-24,433],[171,322],[65,475],[-44,549],[57,295]],[[52339,73106],[302,232],[195,-69],[-9,-291],[236,212],[20,-111],[-139,-282],[-2,-266],[96,-143],[-36,-499],[-183,-289],[53,-314],[143,-10],[70,-274],[106,-90]],[[53191,70912],[-16,-442],[-135,-165],[-86,-185],[-191,-222],[30,-238],[-24,-244],[-136,-133]],[[47592,67756],[-2,682],[449,425],[277,88],[227,155],[107,288],[324,228],[12,427],[161,50],[126,213],[363,97],[51,224],[-73,122],[-96,608],[-17,350],[-104,369]],[[49397,72082],[267,315],[300,100],[175,238],[268,175],[471,102],[459,47],[140,-85],[262,227],[297,4],[113,-134],[190,35]],[[52633,69283],[90,-509],[15,-267],[-49,-470],[21,-263],[-36,-315],[24,-362],[-110,-240],[164,-420],[11,-247],[99,-321],[130,105],[219,-267],[122,-361]],[[59922,70666],[309,-228],[544,613]],[[60775,71051],[112,-701]],[[60887,70350],[-53,-87],[-556,-289],[277,-575],[-92,-98],[-46,-193],[-212,-80],[-66,-207],[-120,-177],[-310,91]],[[59709,68735],[-9,84]],[[64327,65792],[49,28],[11,-158],[217,91],[230,-15],[168,-17],[190,389],[207,369],[176,355]],[[65575,66834],[52,-196]],[[65627,66638],[38,-455]],[[65665,66183],[-142,-2],[-23,-375],[50,-80],[-126,-114],[-1,-235],[-81,-238],[-7,-232]],[[65335,64907],[-56,-122],[-835,290],[-106,584],[-11,133]],[[64113,66085],[-18,419],[75,302],[76,62],[84,-180],[5,-337],[-61,-339]],[[64274,66012],[-77,-41],[-84,114]],[[63326,69092],[58,-254],[-25,-132],[89,-434]],[[63448,68272],[-196,-15],[-69,274],[-248,56]],[[62935,68587],[204,553],[187,-48]],[[60775,71051],[615,600],[105,696],[-26,421],[152,142],[142,359]],[[61763,73269],[119,90],[324,-75],[97,-146],[133,97]],[[62436,73235],[180,-687],[182,-173],[21,-336],[-139,-199],[-65,-449],[193,-548],[340,-315],[143,-438],[-46,-417],[89,0],[3,-307],[153,-302]],[[63490,69064],[-164,28]],[[62935,68587],[-516,46],[-784,1158],[-413,403],[-335,156]],[[65575,66834],[80,196],[35,-50],[-26,-238],[-37,-104]],[[65665,66183],[125,-393],[155,-209],[203,-76],[165,-105],[125,-330],[75,-191],[100,-73],[-1,-128],[-101,-344],[-44,-161],[-117,-184],[-104,-395],[-126,30],[-58,-137],[-44,-292],[34,-385],[-26,-71],[-128,2],[-174,-215],[-27,-281],[-63,-121],[-173,4],[-109,-145],[1,-232],[-134,-160],[-153,54],[-186,-194],[-128,-33]],[[64752,61418],[-91,403],[-217,950]],[[64444,62771],[833,576],[185,1152],[-127,408]],[[96448,42678],[175,-331],[-92,-76],[-93,252],[10,155]],[[96330,42806],[-39,159],[-6,441],[133,-177],[45,-464],[-75,72],[-58,-31]],[[78495,58847],[-66,696],[178,479],[359,110],[261,-83]],[[79227,60049],[229,-226],[126,397],[246,-212]],[[79828,60008],[64,-384],[-34,-690],[-467,-443],[122,-349],[-292,-42],[-240,-232]],[[78981,57868],[-233,84],[-112,301],[-141,594]],[[78495,58847],[-249,265],[-238,-11],[41,452],[-245,-3],[-22,-633],[-150,-841],[-90,-509],[19,-417],[181,-18],[113,-526],[50,-498],[155,-330],[168,-67],[144,-299]],[[78372,55412],[-91,-236],[-183,-69],[-22,296],[-227,252],[-48,-103]],[[77801,55552],[-110,221],[-47,285],[-148,325],[-135,274],[-45,-339],[-53,320],[30,359],[82,553]],[[77375,57550],[135,591],[152,537],[-108,525],[4,268],[-32,321],[-185,458],[-66,289],[96,106],[101,501],[-113,380],[-177,420],[-134,506],[117,104],[127,623],[196,26],[162,249],[159,134]],[[77809,63588],[120,-178],[16,-346],[188,-27],[-68,-606],[6,-517],[293,344],[83,-102],[163,17],[56,201],[210,-40],[211,-468],[18,-568],[224,-502],[-12,-487],[-90,-260]],[[77809,63588],[59,212],[237,374]],[[78105,64174],[25,-135],[148,-16],[-42,659],[144,84]],[[78380,64766],[162,-454],[125,-524],[342,-4],[108,-502],[-178,-151],[-80,-207],[333,-345],[231,-680],[175,-508],[210,-400],[70,-407],[-50,-576]],[[77375,57550],[-27,427],[86,441],[-94,341],[23,627],[-113,299],[-90,689],[-50,727],[-121,477],[-183,-289],[-315,-410],[-156,51],[-172,135],[96,714],[-58,539],[-218,664],[34,208],[-163,74],[-197,469]],[[75657,63733],[-18,464],[97,-88],[6,413]],[[75742,64522],[137,137],[-30,245],[63,196],[11,596],[217,-131],[124,474],[14,281],[153,483],[-8,330],[359,397],[199,-104],[-23,355],[97,105],[-20,219]],[[77035,68105],[162,42],[93,-339],[121,-137],[8,-441],[-11,-475],[-263,-480],[-33,-684],[293,96],[66,-530],[176,-112],[-81,-478],[206,-216],[121,-106],[203,167],[9,-238]],[[78380,64766],[149,141],[221,-3],[271,66],[236,307],[134,-216],[254,-105],[-44,-332],[132,-234],[280,-149]],[[80013,64241],[-371,-493],[-231,-544],[-61,-399],[212,-607],[260,-753],[252,-356],[169,-462],[127,-1066],[-37,-1013],[-232,-379],[-318,-371],[-227,-480],[-346,-536],[-101,369],[78,390],[-206,327]],[[86327,76143],[-106,35],[-120,-195],[-83,-196],[10,-414],[-143,-127],[-50,-102],[-104,-170],[-185,-95],[-121,-154],[-9,-250],[-32,-63],[111,-94],[157,-253]],[[85652,74065],[-40,-139],[-118,-38],[-197,-28],[-108,-260],[-124,21],[-17,-52]],[[85048,73569],[-135,109],[-34,-108],[-81,-48],[-10,109],[-72,52],[-75,92],[76,254],[66,67],[-25,105],[71,311],[-18,94],[-163,63],[-131,154]],[[84517,74823],[227,370],[306,309],[191,409],[131,-181],[241,-21],[-44,304],[429,248],[111,323],[179,-340]],[[85652,74065],[240,-679],[68,-373],[3,-664],[-105,-316],[-252,-111],[-222,-239],[-250,-49],[-31,313],[51,432],[-122,600],[206,97],[-190,493]],[[82410,80559],[-135,-434],[-197,-575],[72,-236],[157,73],[274,-89],[214,212],[223,-184],[251,-403],[-30,-204],[-219,65],[-404,-77],[-195,-164],[-204,-380],[-423,-223],[-277,-306],[-286,117],[-156,52],[-146,-371],[89,-222],[45,-190],[-194,-193],[-200,-309],[-324,-203],[-417,-21],[-448,-200],[-324,-309],[-123,179],[-336,-1],[-411,350],[-274,86],[-369,-80],[-574,129],[-306,-14],[-163,342],[-127,531],[-171,64],[-336,359],[-374,80],[-330,99],[-100,249],[107,673],[-192,464],[-396,216],[-233,306],[-73,402]],[[75742,64522],[-147,914],[-76,-2],[-46,-368],[-152,299],[86,327],[124,34],[128,487],[-160,98],[-257,-8],[-265,79],[-24,400],[-133,29],[-220,248],[-98,-390],[200,-305],[-173,-215],[-62,-210],[171,-154],[-47,-347],[96,-433],[43,-474]],[[74730,64531],[-39,-210],[-189,7],[-343,-120],[16,-433],[-148,-341],[-400,-387],[-311,-678],[-209,-363],[-276,-377],[-1,-265],[-138,-142],[-251,-206],[-129,-31],[-84,-439],[58,-749],[15,-478],[-118,-547],[-1,-978],[-144,-28],[-126,-439],[84,-190],[-253,-163],[-93,-392],[-112,-165],[-263,537],[-128,807],[-107,581],[-97,272],[-148,553],[-69,720],[-48,360],[-253,791],[-115,1116],[-83,737],[1,698],[-54,539],[-404,-345],[-196,69],[-362,698],[133,208],[-82,226],[-326,489]],[[68937,65473],[185,384],[612,-1],[-56,494],[-156,292],[-31,444],[-182,258],[306,604],[323,-44],[290,604],[174,584],[270,578],[-4,411],[236,333],[-224,284],[-96,390],[-99,504],[137,249],[421,-141],[310,86],[268,484]],[[71621,72270],[298,-675],[-28,-470],[111,-295],[-9,-294],[-200,78],[78,-635],[273,-365],[386,-403]],[[72530,69211],[-176,-261],[-108,-538],[269,-218],[262,-283],[362,-323],[381,-75],[160,-293],[215,-54],[334,-135],[231,10],[32,228],[-36,366],[21,248]],[[74477,67883],[170,121],[23,-454]],[[74670,67550],[6,-115],[252,-218],[175,90],[234,-39],[227,17],[20,354],[-113,184]],[[75471,67823],[224,72],[252,428],[321,367],[233,-142],[198,243],[130,-358],[-94,-242],[300,-86]],[[75657,63733],[-79,301],[-16,293],[-53,277],[-116,335],[-256,23],[25,-237],[-87,-321],[-118,117],[-41,-105],[-78,63],[-108,52]],[[74670,67550],[184,429],[150,146],[198,-134],[147,-14],[122,-154]],[[72530,69211],[115,138],[223,-177],[280,-375],[157,-83],[93,-276],[216,-114],[225,-253],[314,-132],[324,-56]],[[68937,65473],[-203,146],[-83,414],[-215,438],[-512,-108],[-451,-11],[-391,-81]],[[67082,66271],[105,669],[400,298],[-23,265],[-133,93],[-7,508],[-266,253],[-112,348],[-137,302]],[[66909,69007],[465,-294],[278,87],[166,-74],[56,126],[194,-50],[361,239],[10,490],[154,326],[207,-1],[31,161],[212,75],[103,-53],[108,162],[-15,346],[118,347],[177,146],[-110,381],[265,-18],[76,207],[-12,221],[139,242],[-32,287],[-66,244],[163,251],[298,121],[319,67],[141,106],[162,65]],[[70877,73214],[205,-269],[82,-442],[457,-233]],[[68841,73220],[85,-70],[201,185],[93,-111],[90,264],[166,-12],[43,84],[29,233],[120,200],[150,-131],[-30,-176],[84,-27],[-26,-484],[110,-189],[97,121],[123,57],[173,258],[192,-42],[286,-1]],[[70827,73379],[50,-165]],[[66909,69007],[252,523],[-23,370],[-210,97],[-22,366],[-91,460],[119,315],[-121,85],[76,419],[113,718]],[[67002,72360],[284,-219],[209,77],[58,261],[219,87],[157,175],[55,460],[234,112],[44,205],[131,-154],[84,-18]],[[69725,75005],[-101,-177],[-303,96],[-26,-332],[301,45],[343,-187],[526,87]],[[70465,74537],[70,-533],[91,58],[169,-131],[-10,-224],[42,-328]],[[72294,76218],[-39,-130],[-438,-312],[-99,-229],[-356,-68],[-105,-368],[-294,77],[-192,-112],[-266,-272],[39,-135],[-79,-132]],[[67002,72360],[-24,484],[-207,21],[-318,510],[-221,63],[-308,292],[-197,53],[-122,-108],[-186,17],[-197,-329],[-244,-112]],[[64978,73251],[-52,408],[40,602],[-216,195],[71,394],[-184,34],[61,485],[262,-141],[244,184],[-202,346],[-80,329],[-224,-147],[-28,-422],[-87,374]],[[62436,73235],[0,0],[-152,461],[55,179],[-87,660],[190,164]],[[62442,74699],[44,-217],[141,-266],[190,-76]],[[62817,74140],[101,17]],[[62918,74157],[327,424],[104,43],[82,-169],[-95,-285],[173,-301],[69,28]],[[63578,73897],[88,-424],[263,-120],[193,-289],[395,-100],[434,153],[27,134]],[[67082,66271],[-523,174],[-303,133],[-313,74],[-118,707],[-133,102],[-214,-103],[-280,-279],[-339,191],[-281,443],[-267,164],[-186,546],[-205,768],[-149,-93],[-177,190],[-104,-224]],[[59999,71781],[-26,440],[68,237]],[[60041,72458],[74,126],[75,127],[15,321],[91,-112],[306,160],[147,-108],[229,1],[320,217],[149,-10],[316,89]],[[62817,74140],[-113,333],[1,89],[-123,-2],[-82,155],[-58,-16]],[[62442,74699],[-109,168],[-207,144],[27,280],[-47,203]],[[62106,75494],[386,89]],[[62492,75583],[57,-151],[106,-100],[-56,-144],[148,-198],[-78,-183],[118,-157],[124,-94],[7,-399]],[[55734,91626],[371,-282],[433,-392],[8,-886],[93,-225]],[[56639,89841],[-478,-163],[-269,-401],[43,-353],[-441,-463],[-537,-495],[-202,-811],[198,-406],[265,-320],[-255,-649],[-289,-135],[-106,-967],[-157,-539],[-337,55],[-158,-456],[-321,-27],[-89,545],[-232,653],[-211,814]],[[58829,81834],[-239,-34],[-85,-127],[-18,-290],[-111,56],[-250,-28],[-73,135],[-104,-100],[-105,83],[-218,11],[-310,139],[-281,45],[-215,-13],[-152,-156],[-133,-23]],[[56535,81532],[-6,257],[-85,267],[166,117],[2,230],[-77,219],[-12,255]],[[56523,82877],[268,-4],[302,217],[64,325],[228,184],[-26,258]],[[57359,83857],[169,97],[298,222]],[[60617,78955],[-222,-46],[-185,-187],[-260,-30],[-239,-215],[14,-308]],[[59287,78304],[-38,62],[-432,146],[-19,215],[-257,-71],[-103,-317],[-215,-426]],[[58223,77913],[-126,99],[-131,-93],[-124,106]],[[57842,78025],[70,63],[49,197],[76,184],[-20,103],[58,46],[27,-80],[164,-17],[74,43],[-52,58],[19,86],[-97,147],[-40,240],[-101,95],[20,195],[-125,155],[-115,21],[-204,180],[-185,-57],[-66,-85]],[[57394,79599],[-118,0],[-69,-135],[-205,-55],[-95,-89],[-129,141],[-178,2],[-172,64],[-120,-123]],[[56308,79404],[-19,154],[-155,157]],[[56134,79715],[55,232],[77,150]],[[56266,80097],[60,-34],[-71,259],[252,479],[138,67],[29,162],[-139,502]],[[56314,83116],[142,-62],[67,-177]],[[56266,80097],[-264,221],[-200,-81],[-131,59],[-165,-123],[-140,204],[-114,-78],[-16,34]],[[55236,80333],[-127,284],[-207,35],[-26,180],[-191,64],[-41,-148],[-151,119],[17,158],[-207,50],[-132,186]],[[54171,81261],[-114,367],[22,199],[-69,308],[-101,205],[77,154],[-64,293]],[[53922,82787],[189,169],[434,266],[350,195],[277,-97],[21,-140],[268,-8]],[[54716,79543],[-21,-236],[-156,-1],[53,-125],[-92,-370]],[[54500,78811],[-53,-97],[-243,-15],[-140,-130],[-229,44]],[[53835,78613],[-398,149],[-62,200],[-274,-100],[-32,-109],[-169,81]],[[52900,78834],[-142,16],[-125,105],[42,141],[-10,102]],[[52665,79198],[83,32],[141,-160],[39,152],[245,-25],[199,104],[133,-18],[87,-118],[26,98],[-40,375],[100,73],[98,266]],[[53776,79977],[206,-186],[157,236],[98,43],[215,-176],[131,30],[128,-109]],[[54711,79815],[-23,-73],[28,-199]],[[56308,79404],[-170,-121],[-131,-391],[-168,-390],[-223,-109]],[[55616,78393],[-173,26],[-213,-152],[0,0]],[[55230,78267],[-104,-86],[-229,111],[-208,247],[-88,71]],[[54601,78610],[-54,194],[-47,7]],[[54716,79543],[141,-148],[103,-62],[233,70],[22,116],[111,17],[135,89],[30,-37],[130,72],[66,136],[91,35],[297,-175],[59,59]],[[57842,78025],[-50,263],[30,246],[-9,253],[-160,342],[-89,243],[-86,171],[-84,56]],[[58223,77913],[6,-149],[-135,-124],[-84,54],[-78,-694]],[[57932,77e3],[-163,60],[-202,209],[-327,-133],[-138,-147],[-408,30],[-213,90],[-108,-42],[-80,236]],[[56293,77303],[-51,101],[65,97],[-69,72],[-87,-129],[-162,167],[-22,237],[-169,136],[-31,183],[-151,226]],[[55907,83612],[-59,485]],[[55848,84097],[318,176],[466,-37],[273,57],[39,-120],[148,-37],[267,-279]],[[55848,84097],[10,433],[136,362],[262,196],[221,-430],[223,11],[53,442]],[[56753,85111],[237,102],[121,-70],[239,-214],[229,-1]],[[56753,85111],[32,340],[-102,-72],[-176,204],[-24,331],[351,161],[350,83],[301,-95],[287,17],[0,0]],[[51718,80315],[16,252],[-56,130]],[[51678,80697],[32,389]],[[51710,81086],[-47,604],[167,0],[70,217],[69,527],[-51,195]],[[51918,82629],[54,122],[232,31],[52,-127],[188,284],[-63,216],[-13,326]],[[52368,83481],[210,-76],[178,88]],[[52756,83493],[4,-222],[281,-135],[-3,-204],[283,108],[156,158],[313,-228],[132,-183]],[[54171,81261],[-124,-60],[-73,66],[-70,-110],[-200,-111],[-103,-144],[-202,-125],[49,-171],[30,-243],[141,-139],[157,-247]],[[52665,79198],[-298,176],[-57,-125],[-236,4]],[[57932,77e3],[-144,-239],[-101,-412],[89,-328]],[[57776,76021],[-239,77],[-283,-181]],[[57254,75917],[-3,-287],[-252,-55],[-196,202],[-222,-159],[-206,17]],[[56375,75635],[-20,381],[-139,185]],[[56216,76201],[46,81],[-30,69],[47,183],[105,180],[-135,248],[-24,211],[68,130]],[[57254,75917],[135,-153],[-86,-360],[-66,-65]],[[57237,75339],[-169,17],[-145,54],[-336,-150],[192,-323],[-141,-94],[-154,-1],[-147,297],[-52,-127],[62,-344],[139,-270],[-105,-126],[155,-265],[137,-167],[4,-326],[-257,153],[82,-294],[-176,-60],[105,-509],[-184,-7],[-228,251],[-104,460],[-49,384],[-108,264],[-143,329],[-18,164]],[[55597,74649],[129,279],[16,187],[91,84],[5,151]],[[55838,75350],[182,51],[106,126],[150,-11],[46,100],[53,19]],[[57302,72158],[-35,-170],[-400,-49],[3,95],[-339,112],[52,245],[152,-194],[216,33],[207,-41],[-7,-100],[151,69]],[[60041,72458],[-102,261],[105,217],[-169,-49],[-233,132],[-191,-331],[-421,-65],[-225,309],[-300,19],[-64,-238],[-192,-69],[-268,307],[-303,-11],[-165,573],[-203,320],[135,447],[-176,276],[308,550],[428,23],[117,438],[529,-76],[334,373],[324,163],[459,13],[485,-406],[399,-223],[323,89],[239,-52],[328,301]],[[61542,75749],[296,27],[268,-282]],[[57776,76021],[33,-222],[243,-186],[-51,-141],[-330,-32],[-118,-178],[-232,-310],[-87,268],[3,119]],[[55597,74649],[-48,40],[-5,127],[-154,193],[-24,274],[23,393],[38,179],[-47,91],[0,0]],[[55380,75946],[-18,183],[120,284],[18,-109],[75,51]],[[55575,76355],[59,-154],[66,-59],[19,-209]],[[55719,75933],[0,0],[-35,-196],[39,-247],[115,-140]],[[55230,78267],[67,-223],[89,-164],[-107,-216]],[[55279,77664],[-126,127],[-192,-8],[-239,96],[-130,-13],[-60,-120],[-99,133],[-59,-239],[136,-270],[61,-178],[127,-215],[106,-128],[105,-240],[246,-218]],[[55155,76391],[-31,-98]],[[55124,76293],[0,0],[-261,213],[-161,207],[-254,171],[-233,424],[56,43],[-127,242],[-5,195],[-179,91],[-85,-249],[-82,193],[6,200],[10,9]],[[53809,78032],[194,-20],[51,98],[94,-94],[109,-12],[-1,161],[97,59],[27,233],[221,153]],[[52900,78834],[-22,-236],[-122,-97],[-206,72],[-60,-232],[-132,-18],[-48,91],[-156,-195],[-134,-28],[-120,124]],[[51576,80352],[30,323],[72,22]],[[50698,81285],[222,113],[0,0]],[[50920,81398],[0,0],[204,-45],[257,120],[176,-252],[153,-135]],[[50920,81398],[143,159],[244,847],[380,241],[231,-16]],[[47490,75948],[101,146],[113,84],[70,-282],[164,1],[47,72],[162,-20],[78,-289],[-129,-156],[-3,-449],[-45,-84],[-11,-272],[-120,-48],[111,-345],[-77,-378],[96,-172],[-38,-156],[-103,-216],[23,-191]],[[47929,73193],[-112,-149],[-146,81],[-143,-64],[42,451],[-26,354],[-124,53],[-67,218],[22,377],[111,210],[20,232],[58,347],[-6,244],[-56,206],[-12,195]],[[50829,76289],[15,-335],[-263,-383],[-356,-122],[-25,-194],[-171,-319],[-107,-469],[108,-329],[-160,-257],[-60,-374],[-210,-115],[-197,-443],[-352,-8],[-265,10],[-174,-203],[-106,-218],[-136,48],[-103,195],[-79,331],[-259,89]],[[47490,75948],[14,410],[-114,250],[393,415],[340,-104],[373,4],[296,-98],[230,30],[449,-19]],[[48278,82851],[46,-412],[-210,-514],[-493,-340],[-393,87],[225,601],[-145,586],[378,451],[210,269]],[[47896,83579],[57,-309],[-57,-309],[172,8],[210,-118]],[[96049,39690],[228,-357],[144,-265],[-105,-138],[-153,155],[-199,259],[-179,306],[-184,406],[-38,195],[119,-8],[156,-196],[122,-196],[89,-161]],[[95032,45793],[78,-198],[-194,3],[-106,355],[166,-140],[56,-20]],[[94910,46301],[-42,-106],[-206,499],[-57,344],[94,0],[100,-461],[111,-276]],[[94680,46144],[-108,-13],[-170,58],[-58,89],[17,228],[183,-90],[91,-121],[45,-151]],[[94344,47211],[65,-183],[12,-116],[-218,245],[-152,206],[-104,192],[41,59],[128,-138],[228,-265]],[[93649,47786],[111,-188],[-56,-33],[-121,131],[-114,237],[14,96],[166,-243]],[[99134,28756],[-105,-310],[-138,-395],[-214,-229],[-48,151],[-116,83],[160,474],[-91,317],[-299,230],[8,209],[201,200],[47,444],[-13,372],[-113,386],[8,102],[-133,237],[-218,510],[-117,408],[104,45],[151,-320],[216,-149],[78,-513],[202,-607],[5,394],[126,-158],[41,-435],[224,-188],[188,-46],[158,220],[141,-67],[-67,-511],[-85,-336],[-212,12],[-74,-175],[26,-248],[-41,-107]],[[97129,26747],[238,301],[167,299],[123,429],[106,146],[41,321],[195,267],[61,-245],[63,-238],[198,233],[80,-243],[0,-242],[-103,-267],[-182,-424],[-142,-232],[103,-277],[-214,-7],[-238,-217],[-75,-377],[-157,-583],[-219,-257],[-138,-164],[-256,12],[-180,190],[-302,40],[-46,212],[149,427],[349,568],[179,109],[200,219]],[[91024,28329],[166,-39],[20,-684],[-95,-198],[-29,-463],[-97,157],[-193,-401],[-57,31],[-171,18],[-171,493],[-38,380],[-160,502],[7,264],[181,-51],[269,-199],[151,79],[217,111]],[[85040,33277],[-294,-296],[-241,-132],[-53,-302],[-103,-234],[-236,-14],[-174,-52],[-246,105],[-199,-62],[-191,-27],[-165,-307],[-81,26],[-140,-163],[-133,-183],[-203,23],[-186,0],[-295,368],[-149,109],[6,330],[138,79],[47,131],[-10,207],[34,400],[-31,341],[-147,582],[-45,329],[12,328],[-111,375],[-7,169],[-123,230],[-35,451],[-158,456],[-39,245],[122,-249],[-93,535],[137,-167],[83,-223],[-5,294],[-138,454],[-26,181],[-65,173],[31,333],[56,141],[38,289],[-29,336],[114,415],[21,-439],[118,396],[225,193],[136,245],[212,212],[126,45],[77,-71],[219,214],[168,64],[42,126],[74,53],[153,-14],[292,169],[151,256],[71,307],[163,293],[13,229],[7,314],[194,489],[117,-497],[119,115],[-99,272],[87,279],[122,-125],[34,439],[152,283],[67,227],[140,98],[4,161],[122,-67],[5,145],[122,82],[134,78],[205,-264],[155,-342],[173,-3],[177,-54],[-59,316],[133,462],[126,150],[-44,144],[121,329],[168,203],[142,-68],[234,108],[-5,294],[-204,190],[148,84],[184,-143],[148,-236],[234,-148],[79,59],[172,-177],[162,164],[105,-50],[65,111],[127,-285],[-74,-308],[-105,-233],[-96,-19],[32,-230],[-81,-288],[-99,-283],[20,-163],[221,-318],[214,-184],[143,-199],[201,-341],[78,1],[145,-148],[43,-178],[265,-195],[183,197],[55,309],[56,255],[34,316],[85,458],[-39,279],[20,167],[-32,330],[37,434],[53,117],[-43,192],[67,305],[52,317],[7,164],[104,216],[78,-282],[19,-361],[70,-70],[11,-242],[101,-293],[21,-326],[-10,-209],[100,-452],[179,217],[92,-243],[133,-225],[-29,-255],[60,-494],[42,-288],[70,-70],[75,-492],[-27,-299],[90,-390],[301,-301],[197,-274],[186,-251],[-37,-139],[159,-361],[108,-623],[111,126],[113,-249],[68,88],[48,-610],[197,-354],[129,-220],[217,-466],[78,-463],[7,-328],[-19,-356],[132,-490],[-16,-509],[-48,-267],[-75,-514],[6,-330],[-55,-413],[-123,-524],[-205,-283],[-102,-446],[-93,-284],[-82,-497],[-107,-287],[-70,-431],[-36,-397],[14,-182],[-159,-200],[-311,-21],[-257,-236],[-127,-223],[-168,-248],[-230,255],[-170,101],[43,301],[-152,-109],[-243,-417],[-240,156],[-158,91],[-159,41],[-269,167],[-179,355],[-52,437],[-64,291],[-137,233],[-267,70],[91,279],[-67,428],[-136,-399],[-247,-106],[146,319],[42,332],[107,282],[-22,427],[-226,-491],[-174,-197],[-106,-458],[-217,237],[9,305],[-174,418],[-147,216],[52,133],[-356,349],[-195,16],[-267,280],[-498,-54],[-359,-206],[-317,-192],[-265,38]],[[72718,56162],[-42,-600],[-116,-164],[-242,-132],[-132,458],[-49,828],[126,935],[192,-320],[129,-406],[134,-599]],[[84517,74823],[-388,-167],[-204,-269],[-300,-157],[148,267],[-58,224],[220,387],[-147,302],[-242,-204],[-314,-400],[-171,-372],[-272,-28],[-142,-268],[147,-390],[227,-94],[9,-259],[220,-168],[311,411],[247,-224],[179,-15],[45,-302],[-393,-161],[-130,-311],[-270,-289],[-142,-403],[299,-316],[109,-567],[169,-527],[189,-443],[-5,-428],[-174,-157],[66,-307],[164,-179],[-43,-469],[-71,-456],[-155,-52],[-203,-623],[-225,-756],[-258,-687],[-382,-532],[-386,-484],[-313,-67],[-170,-255],[-96,186],[-157,-286],[-388,-288],[-294,-88],[-95,-609],[-154,-33],[-73,418],[66,222],[-373,185],[-131,-94]],[[80409,62309],[-228,179],[-8,495],[137,261],[304,161],[159,-13],[62,-220],[-122,-254],[-64,-332],[-240,-277]],[[83826,65878],[-167,-924],[-119,-472],[-146,486],[-32,427],[163,566],[223,436],[127,-172],[-49,-347]],[[53835,78613],[-31,-283],[67,-246]],[[53871,78084],[-221,84],[-226,-204],[15,-286],[-34,-164],[91,-293],[261,-290],[140,-476],[309,-464],[217,3],[68,-127],[-78,-115],[249,-208],[204,-174],[238,-301],[29,-107],[-52,-206],[-154,268],[-242,95],[-116,-372],[200,-214],[-33,-300],[-116,-34],[-148,-494],[-116,-45],[1,176],[57,309],[60,123],[-108,334],[-85,290],[-115,72],[-82,249],[-179,104],[-120,232],[-206,37],[-217,260],[-254,375],[-189,332],[-86,569],[-138,67],[-226,190],[-128,-78],[-161,-267],[-115,-42]],[[54100,73796],[211,50],[-100,-453],[41,-179],[-58,-296],[-213,217],[-141,62],[-387,293],[38,296],[325,-53],[284,63]],[[52419,75383],[139,178],[166,-408],[-39,-762],[-126,36],[-113,-192],[-105,153],[-11,694],[-64,330],[153,-29]],[[52368,83481],[-113,320],[-8,589],[46,155],[80,173],[244,36],[98,159],[223,162],[-9,-296],[-82,-188],[33,-161],[151,-87],[-68,-217],[-83,62],[-200,-415],[76,-280]],[[53436,84143],[88,-289],[-166,-466],[-291,325],[-39,239],[408,191]],[[47896,83579],[233,23],[298,-356],[-149,-395]],[[49140,82584],[1,0],[40,334],[-186,355],[-4,8],[-337,101],[-66,156],[101,258],[-92,158],[-149,-272],[-17,555],[-140,294],[101,595],[216,467],[222,-45],[335,48],[-297,-623],[283,79],[304,-3],[-72,-469],[-250,-516],[287,-37],[22,-61],[248,-679],[190,-93],[171,-656],[79,-227],[337,-110],[-34,-368],[-142,-169],[111,-298],[-250,-302],[-371,6],[-473,-159],[-130,114],[-183,-270],[-257,65],[-195,-220],[-148,115],[407,605],[249,125],[-2,0],[-434,96],[-79,229],[291,179],[-152,310],[52,377],[413,-52]],[[45969,90100],[-64,-373],[314,-392],[-361,-440],[-801,-394],[-240,-105],[-365,85],[-775,182],[273,254],[-605,282],[492,112],[-12,169],[-583,134],[188,375],[421,85],[433,-391],[422,314],[349,-163],[453,307],[461,-41]],[[63495,75906],[146,-303],[141,-408],[130,-27],[85,-156],[-228,-46],[-49,-447],[-48,-202],[-101,-135],[7,-285]],[[62492,75583],[68,94],[207,-165],[149,-34],[38,67],[-136,312],[72,79]],[[61542,75749],[42,246],[-70,393],[-160,212],[-154,66],[-102,177]],[[83564,59146],[-142,438],[238,-21],[97,-207],[-74,-498],[-119,288]],[[84051,57577],[70,162],[30,357],[153,34],[-44,-388],[205,556],[-26,-549],[-100,-190],[-87,-363],[-87,-171],[-171,398],[57,154]],[[85104,56675],[28,-382],[16,-323],[-94,-527],[-102,587],[-130,-292],[89,-425],[-79,-270],[-327,335],[-78,416],[84,274],[-176,273],[-87,-239],[-131,22],[-205,-321],[-46,168],[109,486],[175,161],[151,217],[98,-260],[212,157],[45,257],[196,16],[-16,445],[225,-273],[23,-290],[20,-212]],[[82917,57194],[-369,-546],[136,403],[200,355],[167,399],[146,572],[49,-470],[-183,-317],[-146,-396]],[[83982,62325],[-46,-239],[95,-413],[-73,-478],[-164,-191],[-43,-465],[62,-458],[147,-64],[123,68],[347,-319],[-27,-313],[91,-139],[-29,-265],[-216,283],[-103,302],[-71,-211],[-177,345],[-253,-86],[-138,128],[14,238],[87,146],[-83,133],[-36,-207],[-137,331],[-41,251],[-11,551],[112,-190],[29,901],[90,522],[169,-1],[171,-164],[85,150],[26,-146]],[[83899,58403],[-43,275],[166,-179],[177,1],[-5,-240],[-129,-245],[-176,-173],[-10,268],[20,293]],[[84861,58834],[78,-643],[-214,152],[5,-193],[68,-355],[-132,-129],[-11,405],[-84,30],[-43,348],[163,-46],[-4,218],[-169,440],[266,-13],[77,-214]],[[80461,52985],[204,-198],[214,108],[56,488],[119,108],[333,125],[199,456],[137,364]],[[81723,54436],[126,-299],[58,196],[133,-18],[16,368],[13,284]],[[82069,54967],[214,400],[140,450],[112,2],[143,-291],[13,-251],[183,-160],[231,-173],[-20,-226],[-186,-29],[50,-281],[-205,-196]],[[78372,55412],[64,-54],[164,-347],[116,-386],[16,-388],[-29,-262],[27,-198],[20,-340],[98,-159],[109,-509],[-5,-195],[-197,-38],[-263,426],[-329,457],[-32,294],[-161,385],[-38,477],[-100,314],[30,419],[-61,244]],[[81723,54436],[110,215],[236,316]],[[53809,78032],[62,52]],[[57797,86672],[0,0],[-504,-46],[-489,-211],[-452,-121],[-161,314],[-269,189],[62,567],[-135,520],[133,335],[252,362],[635,624],[185,121],[-28,243],[-387,272]],[[54711,79815],[39,127],[123,-10],[95,60],[7,53],[54,28],[18,131],[64,25],[43,104],[82,0]],[[60669,62194],[161,-666],[77,-529],[152,-281],[379,-544],[154,-328],[151,-332],[87,-198],[136,-173]],[[61966,59143],[-83,-141],[-119,50]],[[61764,59052],[-95,187],[-114,337],[-124,185],[-71,199],[-242,231],[-191,7],[-67,120],[-163,-135],[-168,261],[-87,-430],[-323,121]],[[89411,74393],[-256,-580],[4,-594],[-104,-460],[48,-288],[-145,-406],[-355,-271],[-488,-36],[-396,-657],[-186,221],[-12,431],[-483,-127],[-329,-271],[-325,-11],[282,-424],[-186,-979],[-179,-242],[-135,224],[69,519],[-176,167],[-113,395],[263,177],[145,362],[280,298],[203,394],[553,171],[297,-117],[291,1024],[185,-275],[408,575],[158,224],[174,704],[-47,648],[117,364],[295,105],[152,-798],[-9,-467]],[[90169,77146],[197,244],[62,-647],[-412,-157],[-244,-572],[-436,393],[-152,-630],[-308,-9],[-39,573],[138,443],[296,32],[81,797],[83,449],[326,-600],[213,-194],[195,-122]],[[86769,71100],[154,344],[158,-67],[114,242],[204,-124],[35,-197],[-156,-349],[-114,185],[-143,-134],[-73,-337],[-181,164],[2,273]],[[64752,61418],[-201,-154],[-54,-256],[-6,-196],[-277,-244],[-444,-268],[-249,-406],[-122,-32],[-83,34],[-163,-239],[-177,-111],[-233,-30],[-70,-33],[-61,-152],[-73,-42],[-43,-146],[-137,12],[-89,-78],[-192,30],[-72,336],[8,315],[-46,170],[-54,426],[-80,236],[56,28],[-29,264],[34,111],[-12,251]],[[61883,61244],[121,183],[-28,243],[74,283],[114,-149],[75,52],[321,13],[50,-58],[269,-57],[106,28],[70,-191],[130,96],[199,604],[259,259],[801,221]],[[63448,68272],[109,-497],[137,-131],[47,-203],[190,-242],[16,-237],[-27,-192],[35,-193],[80,-162],[37,-189],[41,-141]],[[64274,66012],[53,-220]],[[61883,61244],[-37,246],[-83,173],[-22,230],[-143,206],[-148,483],[-79,469],[-192,397],[-124,94],[-184,549],[-32,400],[12,342],[-159,638],[-130,225],[-150,119],[-92,330],[15,130],[-77,299],[-81,128],[-108,429],[-170,464],[-141,395],[-139,-2],[44,316],[12,201],[34,230]],[[36483,6883],[141,0],[414,125],[419,-125],[342,-248],[120,-350],[33,-248],[11,-293],[-430,-181],[-452,-146],[-522,-136],[-582,-113],[-658,34],[-365,192],[49,237],[593,158],[239,192],[174,248],[126,214],[168,203],[180,238],[0,-1]],[[31586,5612],[625,-23],[599,-56],[207,237],[147,203],[288,-237],[-82,-294],[-81,-259],[-582,79],[-621,-34],[-348,192],[0,22],[-152,170]],[[29468,10787],[0,0],[190,67],[321,-22],[82,293],[16,215],[-6,462],[158,271],[256,90],[147,-214],[65,-214],[120,-260],[92,-248],[76,-260],[33,-259],[-49,-226],[-76,-214],[-326,-79],[-311,-113],[-364,11],[136,226],[-327,-79],[-310,-79],[-212,169],[-16,237],[305,226]],[[21575,10427],[0,0],[174,101],[353,-79],[403,-45],[305,-79],[304,68],[163,-327],[-217,45],[-337,-23],[-343,23],[-376,-34],[-283,113],[-146,237]],[[15938,9411],[0,0],[60,192],[332,-102],[359,-90],[332,102],[-158,-203],[-261,-147],[-386,45],[-278,203]],[[14643,9524],[0,0],[202,124],[277,-135],[425,-226],[-164,23],[-359,56],[-381,158]],[[4524,6568],[0,0],[169,214],[517,-90],[277,-181],[212,-203],[76,-260],[-533,-79],[-364,204],[-163,203],[-11,34],[-180,158]],[[99999,3044],[0,-3044],[-99999,0],[0,3044],[16,-4],[245,335],[501,-181],[32,21],[294,183],[38,-6],[32,-5],[402,-239],[352,239],[63,33],[816,102],[265,-135],[130,-68],[419,-192],[789,-147],[625,-180],[1072,-136],[800,158],[1181,-113],[669,-180],[734,169],[773,158],[60,271],[-1094,22],[-898,136],[-234,225],[-745,125],[49,259],[103,237],[104,214],[-55,237],[-462,158],[-212,204],[-430,180],[675,-34],[642,91],[402,-192],[495,169],[457,214],[223,192],[-98,237],[-359,158],[-408,169],[-571,34],[-500,79],[-539,57],[-180,214],[-359,181],[-217,203],[-87,654],[136,-56],[250,-181],[457,57],[441,79],[228,-249],[441,57],[370,124],[348,158],[315,192],[419,56],[-11,215],[-97,214],[81,203],[359,102],[163,-192],[425,113],[321,146],[397,12],[375,56],[376,136],[299,124],[337,124],[218,-34],[190,-45],[414,79],[370,-102],[381,12],[364,79],[375,-57],[414,-56],[386,22],[403,-11],[413,-11],[381,22],[283,170],[337,90],[349,-124],[331,101],[300,203],[179,-180],[98,-203],[180,-192],[288,169],[332,-214],[375,-68],[321,-158],[392,34],[354,101],[418,-22],[376,-79],[381,-102],[147,249],[-180,191],[-136,204],[-359,45],[-158,214],[-60,214],[-98,429],[213,-79],[364,-34],[359,34],[327,-90],[283,-169],[119,-203],[376,-34],[359,79],[381,113],[342,67],[283,-135],[370,45],[239,440],[224,-259],[321,-102],[348,56],[228,-225],[365,-23],[337,-68],[332,-124],[218,215],[108,203],[278,-226],[381,57],[283,-125],[190,-191],[370,56],[288,124],[283,147],[337,79],[392,68],[354,79],[272,124],[163,180],[65,249],[-32,236],[-87,226],[-98,226],[-87,226],[-71,203],[-16,225],[27,226],[130,214],[109,237],[44,226],[-55,248],[-32,226],[136,260],[152,169],[180,214],[190,181],[223,169],[109,248],[152,158],[174,147],[267,34],[174,180],[196,113],[228,68],[202,147],[157,180],[218,68],[163,-147],[-103,-192],[-283,-169],[-120,-124],[-206,90],[-229,-56],[-190,-136],[-202,-146],[-136,-170],[-38,-225],[17,-215],[130,-191],[-190,-136],[-261,-45],[-153,-192],[-163,-180],[-174,-249],[-44,-214],[98,-237],[147,-181],[229,-135],[212,-181],[114,-225],[60,-215],[82,-225],[130,-192],[82,-215],[38,-530],[81,-214],[22,-226],[87,-226],[-38,-304],[-152,-237],[-163,-192],[-370,-79],[-125,-203],[-169,-192],[-419,-215],[-370,-90],[-348,-124],[-376,-124],[-223,-237],[-446,-23],[-489,23],[-441,-45],[-468,0],[87,-226],[424,-101],[311,-158],[174,-204],[-310,-180],[-479,56],[-397,-146],[-17,-237],[-11,-226],[327,-192],[60,-214],[353,-215],[588,-90],[500,-158],[398,-180],[506,-181],[690,-90],[681,-158],[473,-170],[517,-191],[272,-271],[136,-215],[337,204],[457,169],[484,180],[577,147],[495,158],[691,11],[680,-79],[560,-135],[180,248],[386,169],[702,12],[550,124],[522,124],[577,79],[614,102],[430,146],[-196,203],[-119,203],[0,215],[-539,-23],[-571,-90],[-544,0],[-77,214],[39,429],[125,124],[397,136],[468,135],[337,169],[337,170],[251,225],[380,102],[376,79],[190,45],[430,23],[408,79],[343,112],[337,136],[305,135],[386,181],[245,192],[261,169],[82,226],[-294,135],[98,237],[185,181],[288,112],[305,136],[283,180],[217,226],[136,271],[202,158],[331,-34],[136,-192],[332,-22],[11,214],[142,226],[299,-57],[71,-214],[331,-34],[360,102],[348,67],[315,-34],[120,-237],[305,192],[283,102],[315,79],[310,79],[283,135],[310,91],[240,124],[168,203],[207,-147],[288,79],[202,-271],[157,-203],[316,113],[125,226],[283,158],[365,-34],[108,-215],[229,215],[299,68],[326,22],[294,-11],[310,-68],[300,-34],[130,-192],[180,-169],[304,102],[327,22],[315,0],[310,12],[278,79],[294,67],[245,158],[261,102],[283,56],[212,158],[152,316],[158,192],[288,-90],[109,-203],[239,-136],[289,45],[196,-203],[206,-146],[283,135],[98,248],[250,102],[289,192],[272,79],[326,112],[218,125],[228,135],[218,124],[261,-68],[250,203],[180,158],[261,-11],[229,136],[54,203],[234,158],[228,113],[278,90],[256,45],[244,-34],[262,-56],[223,-158],[27,-249],[245,-191],[168,-158],[332,-68],[185,-158],[229,-158],[266,-34],[223,113],[240,237],[261,-124],[272,-68],[261,-68],[272,-45],[277,0],[229,-598],[-11,-147],[-33,-259],[-266,-147],[-218,-214],[38,-226],[310,11],[-38,-225],[-141,-215],[-131,-237],[212,-180],[321,-57],[321,102],[153,226],[92,214],[153,181],[174,169],[70,203],[147,282],[174,57],[316,22],[277,68],[283,90],[136,226],[82,214],[190,215],[272,146],[234,113],[153,192],[157,101],[202,91],[277,-57],[250,57],[272,67],[305,-33],[201,158],[142,383],[103,-158],[131,-271],[234,-112],[266,-46],[267,68],[283,-45],[261,-11],[174,56],[234,-34],[212,-124],[250,79],[300,0],[255,79],[289,-79],[185,192],[141,192],[191,158],[348,429],[179,-79],[212,-158],[185,-203],[354,-350],[272,-12],[256,0],[299,68],[299,79],[229,158],[190,169],[310,23],[207,124],[218,-113],[141,-180],[196,-181],[305,23],[190,-147],[332,-147],[348,-56],[288,45],[218,181],[185,180],[250,45],[251,-79],[288,-56],[261,90],[250,0],[245,-56],[256,-57],[250,102],[299,90],[283,23],[316,0],[255,56],[251,45],[76,282],[11,237],[174,-158],[49,-259],[92,-237],[115,-192],[234,-102],[315,34],[365,12],[250,33],[364,0],[262,12],[364,-23],[310,-45],[196,-181],[-54,-214],[179,-169],[299,-136],[310,-146],[360,-102],[375,-90],[283,-90],[315,-12],[180,192],[245,-158],[212,-180],[245,-136],[337,-56],[321,-68],[136,-226],[316,-135],[212,-203],[310,-90],[321,11],[299,-34],[332,11],[332,-45],[310,-79],[288,-135],[289,-113],[195,-169],[-32,-226],[-147,-203],[-125,-260],[-98,-203],[-131,-237],[-364,-90],[-163,-203],[-360,-124],[-125,-226],[-190,-214],[-201,-181],[-115,-237],[-70,-214],[-28,-260],[6,-214],[158,-226],[60,-214],[130,-204],[517,-78],[109,-249],[-501,-90],[-424,-124],[-528,-23],[-234,-327],[-49,-271],[-119,-214],[-147,-215],[370,-191],[141,-237],[239,-215],[338,-192],[386,-180],[419,-181],[636,-180],[142,-282],[800,-125],[53,-44],[208,-170],[767,147],[636,-181],[479,-139]],[[59092,72066],[19,3],[40,139],[200,-8],[253,172],[-188,-245],[21,-108]],[[59437,72019],[-30,20],[-53,-44],[-42,12],[-14,-22],[-5,59],[-20,35],[-54,6],[-75,-49],[-52,30]],[[59437,72019],[8,-46],[-285,-234],[-136,74],[-64,232],[132,21]],[[45272,64166],[13,267],[106,157],[91,300],[-18,195],[96,406],[155,366],[93,93],[74,336],[6,307],[100,356],[185,210],[177,588],[5,8],[139,221],[259,64],[218,393],[140,154],[232,481],[-70,716],[106,495],[37,304],[179,389],[278,263],[206,238],[186,596],[87,354],[205,-3],[167,-244],[264,39],[288,-127],[121,-6]],[[56944,64499],[0,2120],[0,2048],[-83,464],[71,356],[-43,246],[101,276]],[[56990,70009],[369,10],[268,-152],[275,-171],[129,-89],[214,182],[114,165],[245,48],[198,-73],[75,-286],[65,189],[222,-136],[217,-33],[137,145]],[[59673,68968],[27,-149],[-78,-232],[-60,-435],[-75,-300],[-65,-100],[-93,186],[-125,257],[-198,825],[-29,-52],[115,-608],[171,-579],[210,-897],[102,-313],[90,-325],[249,-638],[-55,-100],[9,-374],[323,-517],[49,-118]],[[53191,70912],[326,-198],[117,50],[232,-96],[368,-258],[130,-512],[250,-111],[391,-242],[296,-286],[136,150],[133,264],[-65,442],[87,280],[200,270],[192,78],[375,-118],[95,-257],[104,-3],[88,-98],[276,-67],[68,-191]],[[59804,55e3],[-164,627],[-127,133],[-48,231],[-141,280],[-171,42],[95,328],[147,14],[42,176],[-3,449]],[[61764,59052],[-98,-255],[-94,-269],[22,-159],[4,-176],[155,-9],[67,41],[62,-103]],[[61882,58122],[-61,-204],[103,-317],[102,-277],[106,-206],[909,-683],[233,3]],[[61966,59143],[66,-178],[-9,-240],[-158,-137],[119,-158]],[[61984,58430],[-102,-308]],[[61984,58430],[91,-106],[54,-238],[125,-241],[138,-2],[262,147],[302,68],[245,179],[138,38],[99,105],[158,20],[0,0]],[[58449,51176],[-166,-178],[-67,59]],[[58564,53850],[115,157],[176,-129],[224,135],[195,-1],[171,265]],[[55279,77664],[0,-1],[100,2],[-69,-253],[134,-222],[-41,-271],[-65,-25]],[[55338,76894],[-52,-53],[-90,-134],[-41,-316]],[[55719,75933],[35,-5],[13,118],[164,89],[62,23]],[[55993,76158],[95,33],[128,10]],[[55993,76158],[-9,43],[33,68],[31,140],[-39,-3],[-54,107],[-46,27],[-36,92],[-52,36],[-40,81],[-50,-32],[-38,-191],[-66,-42]],[[55627,76484],[22,50],[-106,119],[-91,62],[-40,80],[-74,99]],[[55380,75946],[-58,44],[-78,188],[-120,115]],[[55627,76484],[-52,-129]],[[32866,58026],[160,75],[58,-20],[-11,-430],[-232,-63],[-50,52],[81,158],[-6,228]]],bbox:[-180,-90,180.00000000000006,83.64513000000001],transform:{scale:[.0036000360003600037,.0017364686646866468],translate:[-180,-90]},objects:{features:{type:"GeometryCollection",geometries:[{arcs:[[[0]],[[1]],[[2]]],type:"MultiPolygon",properties:{id:"FJI",name:"Fiji",name_long:"Fiji"}},{arcs:[[3,4,5,6,7,8,9,10,11]],type:"Polygon",properties:{id:"TZA",name:"Tanzania",name_long:"Tanzania"}},{arcs:[[12,13,14,15]],type:"Polygon",properties:{id:"SAH",name:"W. Sahara",name_long:"Western Sahara"}},{arcs:[[[16,17,18,19]],[[20]],[[21]],[[22]],[[23]],[[24]],[[25]],[[26]],[[27]],[[28]],[[29]],[[30]],[[31]],[[32]],[[33]],[[34]],[[35]],[[36]],[[37]],[[38]],[[39]],[[40]],[[41]],[[42]],[[43]],[[44]],[[45]],[[46]],[[47]],[[48]]],type:"MultiPolygon",properties:{id:"CAN",name:"Canada",name_long:"Canada"}},{arcs:[[[-18,49]],[[-20,50,51,52]],[[53]],[[54]],[[55]],[[56]],[[57]],[[58]],[[59]],[[60]]],type:"MultiPolygon",properties:{id:"USA",name:"United States of America",name_long:"United States"}},{arcs:[[61,62,63,64,65,66]],type:"Polygon",properties:{id:"KAZ",name:"Kazakhstan",name_long:"Kazakhstan"}},{arcs:[[-64,67,68,69,70]],type:"Polygon",properties:{id:"UZB",name:"Uzbekistan",name_long:"Uzbekistan"}},{arcs:[[[71,72]],[[73]],[[74]],[[75]]],type:"MultiPolygon",properties:{id:"PNG",name:"Papua New Guinea",name_long:"Papua New Guinea"}},{arcs:[[[-73,76]],[[77,78]],[[79]],[[80,81]],[[82]],[[83]],[[84]],[[85]],[[86]],[[87]],[[88]],[[89]],[[90]]],type:"MultiPolygon",properties:{id:"IDN",name:"Indonesia",name_long:"Indonesia"}},{arcs:[[[91,92]],[[93,94,95,96,97,98]]],type:"MultiPolygon",properties:{id:"ARG",name:"Argentina",name_long:"Argentina"}},{arcs:[[[-93,99]],[[-96,100,101,102]]],type:"MultiPolygon",properties:{id:"CHL",name:"Chile",name_long:"Chile"}},{arcs:[[-9,103,104,105,106,107,108,109,110,111,112]],type:"Polygon",properties:{id:"COD",name:"Dem. Rep. Congo",name_long:"Democratic Republic of the Congo"}},{arcs:[[113,114,115,116]],type:"Polygon",properties:{id:"SOM",name:"Somalia",name_long:"Somalia"}},{arcs:[[-4,117,118,119,-114,120]],type:"Polygon",properties:{id:"KEN",name:"Kenya",name_long:"Kenya"}},{arcs:[[121,122,123,124,125,126,127,128]],type:"Polygon",properties:{id:"SDN",name:"Sudan",name_long:"Sudan"}},{arcs:[[-123,129,130,131,132]],type:"Polygon",properties:{id:"TCD",name:"Chad",name_long:"Chad"}},{arcs:[[133,134]],type:"Polygon",properties:{id:"HTI",name:"Haiti",name_long:"Haiti"}},{arcs:[[-134,135]],type:"Polygon",properties:{id:"DOM",name:"Dominican Rep.",name_long:"Dominican Republic"}},{arcs:[[[-67,136,137,138,139,140,141,142,143,144,145,146,147,148,149,150,151]],[[152]],[[153]],[[154]],[[155]],[[156]],[[157]],[[158]],[[159,160,161]],[[162]],[[163]],[[164]],[[165]],[[166,167]]],type:"MultiPolygon",properties:{id:"RUS",name:"Russia",name_long:"Russian Federation"}},{arcs:[[[168]],[[169]],[[170]]],type:"MultiPolygon",properties:{id:"BHS",name:"Bahamas",name_long:"Bahamas"}},{arcs:[[171]],type:"Polygon",properties:{id:"FLK",name:"Falkland Is.",name_long:"Falkland Islands / Malvinas"}},{arcs:[[[-147,172,173,174]],[[175]],[[176]],[[177]]],type:"MultiPolygon",properties:{id:"NOR",name:"Norway",name_long:"Norway"}},{arcs:[[178]],type:"Polygon",properties:{id:"GRL",name:"Greenland",name_long:"Greenland"}},{arcs:[[179]],type:"Polygon",properties:{id:"ATF",name:"Fr. S. Antarctic Lands",name_long:"French Southern and Antarctic Lands"}},{arcs:[[-78,180]],type:"Polygon",properties:{id:"TLS",name:"Timor-Leste",name_long:"Timor-Leste"}},{arcs:[[181,182,183,184,185,186,187],[188]],type:"Polygon",properties:{id:"ZAF",name:"South Africa",name_long:"South Africa"}},{arcs:[[-189]],type:"Polygon",properties:{id:"LSO",name:"Lesotho",name_long:"Lesotho"}},{arcs:[[-52,189,190,191,192]],type:"Polygon",properties:{id:"MEX",name:"Mexico",name_long:"Mexico"}},{arcs:[[-94,193,194]],type:"Polygon",properties:{id:"URY",name:"Uruguay",name_long:"Uruguay"}},{arcs:[[-99,195,196,197,198,199,200,201,202,203,-194]],type:"Polygon",properties:{id:"BRA",name:"Brazil",name_long:"Brazil"}},{arcs:[[-97,-103,204,-197,205]],type:"Polygon",properties:{id:"BOL",name:"Bolivia",name_long:"Bolivia"}},{arcs:[[-102,206,207,208,-198,-205]],type:"Polygon",properties:{id:"PER",name:"Peru",name_long:"Peru"}},{arcs:[[-199,-209,209,210,211,212,213]],type:"Polygon",properties:{id:"COL",name:"Colombia",name_long:"Colombia"}},{arcs:[[-212,214,215,216]],type:"Polygon",properties:{id:"PAN",name:"Panama",name_long:"Panama"}},{arcs:[[-216,217,218,219]],type:"Polygon",properties:{id:"CRI",name:"Costa Rica",name_long:"Costa Rica"}},{arcs:[[-219,220,221,222]],type:"Polygon",properties:{id:"NIC",name:"Nicaragua",name_long:"Nicaragua"}},{arcs:[[-222,223,224,225,226]],type:"Polygon",properties:{id:"HND",name:"Honduras",name_long:"Honduras"}},{arcs:[[-225,227,228]],type:"Polygon",properties:{id:"SLV",name:"El Salvador",name_long:"El Salvador"}},{arcs:[[-192,229,230,-226,-229,231]],type:"Polygon",properties:{id:"GTM",name:"Guatemala",name_long:"Guatemala"}},{arcs:[[-191,232,-230]],type:"Polygon",properties:{id:"BLZ",name:"Belize",name_long:"Belize"}},{arcs:[[-200,-214,233,234]],type:"Polygon",properties:{id:"VEN",name:"Venezuela",name_long:"Venezuela"}},{arcs:[[-201,-235,235,236]],type:"Polygon",properties:{id:"GUY",name:"Guyana",name_long:"Guyana"}},{arcs:[[-202,-237,237,238]],type:"Polygon",properties:{id:"SUR",name:"Suriname",name_long:"Suriname"}},{arcs:[[[-203,-239,239]],[[240,241,242,243,244,245,246,247]],[[248]]],type:"MultiPolygon",properties:{id:"FRA",name:"France",name_long:"France"}},{arcs:[[-208,249,-210]],type:"Polygon",properties:{id:"ECU",name:"Ecuador",name_long:"Ecuador"}},{arcs:[[250]],type:"Polygon",properties:{id:"PRI",name:"Puerto Rico",name_long:"Puerto Rico"}},{arcs:[[251]],type:"Polygon",properties:{id:"JAM",name:"Jamaica",name_long:"Jamaica"}},{arcs:[[252]],type:"Polygon",properties:{id:"CUB",name:"Cuba",name_long:"Cuba"}},{arcs:[[-184,253,254,255]],type:"Polygon",properties:{id:"ZWE",name:"Zimbabwe",name_long:"Zimbabwe"}},{arcs:[[-183,256,257,-254]],type:"Polygon",properties:{id:"BWA",name:"Botswana",name_long:"Botswana"}},{arcs:[[-182,258,259,260,-257]],type:"Polygon",properties:{id:"NAM",name:"Namibia",name_long:"Namibia"}},{arcs:[[261,262,263,264,265,266,267]],type:"Polygon",properties:{id:"SEN",name:"Senegal",name_long:"Senegal"}},{arcs:[[-264,268,269,270,271,272,273]],type:"Polygon",properties:{id:"MLI",name:"Mali",name_long:"Mali"}},{arcs:[[-14,274,-269,-263,275]],type:"Polygon",properties:{id:"MRT",name:"Mauritania",name_long:"Mauritania"}},{arcs:[[276,277,278,279,280]],type:"Polygon",properties:{id:"BEN",name:"Benin",name_long:"Benin"}},{arcs:[[-132,281,282,-280,283,-271,284,285]],type:"Polygon",properties:{id:"NER",name:"Niger",name_long:"Niger"}},{arcs:[[-281,-283,286,287]],type:"Polygon",properties:{id:"NGA",name:"Nigeria",name_long:"Nigeria"}},{arcs:[[-131,288,289,290,291,292,-287,-282]],type:"Polygon",properties:{id:"CMR",name:"Cameroon",name_long:"Cameroon"}},{arcs:[[-278,293,294,295]],type:"Polygon",properties:{id:"TGO",name:"Togo",name_long:"Togo"}},{arcs:[[-295,296,297,298]],type:"Polygon",properties:{id:"GHA",name:"Ghana",name_long:"Ghana"}},{arcs:[[-273,299,-298,300,301,302]],type:"Polygon",properties:{id:"CIV",name:"C\xF4te d'Ivoire",name_long:"C\xF4te d'Ivoire"}},{arcs:[[-265,-274,-303,303,304,305,306]],type:"Polygon",properties:{id:"GIN",name:"Guinea",name_long:"Guinea"}},{arcs:[[-266,-307,307]],type:"Polygon",properties:{id:"GNB",name:"Guinea-Bissau",name_long:"Guinea-Bissau"}},{arcs:[[-302,308,309,-304]],type:"Polygon",properties:{id:"LBR",name:"Liberia",name_long:"Liberia"}},{arcs:[[-305,-310,310]],type:"Polygon",properties:{id:"SLE",name:"Sierra Leone",name_long:"Sierra Leone"}},{arcs:[[-272,-284,-279,-296,-299,-300]],type:"Polygon",properties:{id:"BFA",name:"Burkina Faso",name_long:"Burkina Faso"}},{arcs:[[-109,311,-289,-130,-122,312]],type:"Polygon",properties:{id:"CAF",name:"Central African Rep.",name_long:"Central African Republic"}},{arcs:[[-108,313,314,315,-290,-312]],type:"Polygon",properties:{id:"COG",name:"Congo",name_long:"Republic of the Congo"}},{arcs:[[-291,-316,316,317]],type:"Polygon",properties:{id:"GAB",name:"Gabon",name_long:"Gabon"}},{arcs:[[-292,-318,318]],type:"Polygon",properties:{id:"GNQ",name:"Eq. Guinea",name_long:"Equatorial Guinea"}},{arcs:[[-8,319,320,-255,-258,-261,321,-104]],type:"Polygon",properties:{id:"ZMB",name:"Zambia",name_long:"Zambia"}},{arcs:[[-7,322,-320]],type:"Polygon",properties:{id:"MWI",name:"Malawi",name_long:"Malawi"}},{arcs:[[-6,323,-187,324,-185,-256,-321,-323]],type:"Polygon",properties:{id:"MOZ",name:"Mozambique",name_long:"Mozambique"}},{arcs:[[-186,-325]],type:"Polygon",properties:{id:"SWZ",name:"eSwatini",name_long:"Kingdom of eSwatini"}},{arcs:[[[-105,-322,-260,325]],[[-107,326,-314]]],type:"MultiPolygon",properties:{id:"AGO",name:"Angola",name_long:"Angola"}},{arcs:[[-10,-113,327]],type:"Polygon",properties:{id:"BDI",name:"Burundi",name_long:"Burundi"}},{arcs:[[328,329,330,331,332,333,334,335]],type:"Polygon",properties:{id:"ISR",name:"Israel",name_long:"Israel"}},{arcs:[[-335,336,337]],type:"Polygon",properties:{id:"LBN",name:"Lebanon",name_long:"Lebanon"}},{arcs:[[338]],type:"Polygon",properties:{id:"MDG",name:"Madagascar",name_long:"Madagascar"}},{arcs:[[-330,339]],type:"Polygon",properties:{id:"PSX",name:"Palestine",name_long:"Palestine"}},{arcs:[[-268,340]],type:"Polygon",properties:{id:"GMB",name:"Gambia",name_long:"The Gambia"}},{arcs:[[341,342,343]],type:"Polygon",properties:{id:"TUN",name:"Tunisia",name_long:"Tunisia"}},{arcs:[[-13,344,345,-342,346,-285,-270,-275]],type:"Polygon",properties:{id:"DZA",name:"Algeria",name_long:"Algeria"}},{arcs:[[-329,347,348,349,350,-331,-340]],type:"Polygon",properties:{id:"JOR",name:"Jordan",name_long:"Jordan"}},{arcs:[[351,352,353,354,355]],type:"Polygon",properties:{id:"ARE",name:"United Arab Emirates",name_long:"United Arab Emirates"}},{arcs:[[356,357]],type:"Polygon",properties:{id:"QAT",name:"Qatar",name_long:"Qatar"}},{arcs:[[358,359,360]],type:"Polygon",properties:{id:"KWT",name:"Kuwait",name_long:"Kuwait"}},{arcs:[[-349,361,362,363,364,-361,365]],type:"Polygon",properties:{id:"IRQ",name:"Iraq",name_long:"Iraq"}},{arcs:[[[-353,366]],[[-355,367,368,369]]],type:"MultiPolygon",properties:{id:"OMN",name:"Oman",name_long:"Oman"}},{arcs:[[[370]],[[371]]],type:"MultiPolygon",properties:{id:"VUT",name:"Vanuatu",name_long:"Vanuatu"}},{arcs:[[372,373,374,375]],type:"Polygon",properties:{id:"KHM",name:"Cambodia",name_long:"Cambodia"}},{arcs:[[-373,376,377,378,379,380]],type:"Polygon",properties:{id:"THA",name:"Thailand",name_long:"Thailand"}},{arcs:[[-374,-381,381,382,383]],type:"Polygon",properties:{id:"LAO",name:"Laos",name_long:"Lao PDR"}},{arcs:[[-380,384,385,386,387,-382]],type:"Polygon",properties:{id:"MMR",name:"Myanmar",name_long:"Myanmar"}},{arcs:[[-375,-384,388,389]],type:"Polygon",properties:{id:"VNM",name:"Vietnam",name_long:"Vietnam"}},{arcs:[[-149,390,391,392,393]],type:"Polygon",properties:{id:"PRK",name:"North Korea",name_long:"Dem. Rep. Korea"}},{arcs:[[-392,394]],type:"Polygon",properties:{id:"KOR",name:"South Korea",name_long:"Republic of Korea"}},{arcs:[[-151,395]],type:"Polygon",properties:{id:"MNG",name:"Mongolia",name_long:"Mongolia"}},{arcs:[[-387,396,397,398,399,400,401,402,403]],type:"Polygon",properties:{id:"IND",name:"India",name_long:"India"}},{arcs:[[-386,404,-397]],type:"Polygon",properties:{id:"BGD",name:"Bangladesh",name_long:"Bangladesh"}},{arcs:[[-403,405]],type:"Polygon",properties:{id:"BTN",name:"Bhutan",name_long:"Bhutan"}},{arcs:[[-401,406]],type:"Polygon",properties:{id:"NPL",name:"Nepal",name_long:"Nepal"}},{arcs:[[-399,407,408,409,410]],type:"Polygon",properties:{id:"PAK",name:"Pakistan",name_long:"Pakistan"}},{arcs:[[-70,411,412,-410,413,414]],type:"Polygon",properties:{id:"AFG",name:"Afghanistan",name_long:"Afghanistan"}},{arcs:[[-69,415,416,-412]],type:"Polygon",properties:{id:"TJK",name:"Tajikistan",name_long:"Tajikistan"}},{arcs:[[-63,417,-416,-68]],type:"Polygon",properties:{id:"KGZ",name:"Kyrgyzstan",name_long:"Kyrgyzstan"}},{arcs:[[-65,-71,-415,418,419]],type:"Polygon",properties:{id:"TKM",name:"Turkmenistan",name_long:"Turkmenistan"}},{arcs:[[-364,420,421,422,423,424,-419,-414,-409,425]],type:"Polygon",properties:{id:"IRN",name:"Iran",name_long:"Iran"}},{arcs:[[-336,-338,426,427,-362,-348]],type:"Polygon",properties:{id:"SYR",name:"Syria",name_long:"Syria"}},{arcs:[[-423,428,429,430,431]],type:"Polygon",properties:{id:"ARM",name:"Armenia",name_long:"Armenia"}},{arcs:[[-174,432,433]],type:"Polygon",properties:{id:"SWE",name:"Sweden",name_long:"Sweden"}},{arcs:[[-142,434,435,436,437]],type:"Polygon",properties:{id:"BLR",name:"Belarus",name_long:"Belarus"}},{arcs:[[-141,438,-167,439,440,441,442,443,444,445,-435]],type:"Polygon",properties:{id:"UKR",name:"Ukraine",name_long:"Ukraine"}},{arcs:[[-160,446,-436,-446,447,448,449,450]],type:"Polygon",properties:{id:"POL",name:"Poland",name_long:"Poland"}},{arcs:[[451,452,453,454,455,456,457]],type:"Polygon",properties:{id:"AUT",name:"Austria",name_long:"Austria"}},{arcs:[[-444,458,459,460,461,-452,462]],type:"Polygon",properties:{id:"HUN",name:"Hungary",name_long:"Hungary"}},{arcs:[[-442,463]],type:"Polygon",properties:{id:"MDA",name:"Moldova",name_long:"Moldova"}},{arcs:[[-441,464,465,466,-459,-443,-464]],type:"Polygon",properties:{id:"ROU",name:"Romania",name_long:"Romania"}},{arcs:[[-162,467,468,-437,-447]],type:"Polygon",properties:{id:"LTU",name:"Lithuania",name_long:"Lithuania"}},{arcs:[[-143,-438,-469,469,470]],type:"Polygon",properties:{id:"LVA",name:"Latvia",name_long:"Latvia"}},{arcs:[[-144,-471,471]],type:"Polygon",properties:{id:"EST",name:"Estonia",name_long:"Estonia"}},{arcs:[[-241,472,473,474,475,476,477,-450,478,-456,479]],type:"Polygon",properties:{id:"DEU",name:"Germany",name_long:"Germany"}},{arcs:[[-466,480,481,482,483,484]],type:"Polygon",properties:{id:"BGR",name:"Bulgaria",name_long:"Bulgaria"}},{arcs:[[[-483,485,486,487,488]],[[489]]],type:"MultiPolygon",properties:{id:"GRC",name:"Greece",name_long:"Greece"}},{arcs:[[[-363,-428,490,491,-430,-421]],[[-482,492,-486]]],type:"MultiPolygon",properties:{id:"TUR",name:"Turkey",name_long:"Turkey"}},{arcs:[[-488,493,494,495,496]],type:"Polygon",properties:{id:"ALB",name:"Albania",name_long:"Albania"}},{arcs:[[-461,497,498,499,500,501]],type:"Polygon",properties:{id:"HRV",name:"Croatia",name_long:"Croatia"}},{arcs:[[-242,-480,-455,502]],type:"Polygon",properties:{id:"CHE",name:"Switzerland",name_long:"Switzerland"}},{arcs:[[-248,503,-473]],type:"Polygon",properties:{id:"LUX",name:"Luxembourg",name_long:"Luxembourg"}},{arcs:[[-247,504,505,-474,-504]],type:"Polygon",properties:{id:"BEL",name:"Belgium",name_long:"Belgium"}},{arcs:[[-475,-506,506]],type:"Polygon",properties:{id:"NLD",name:"Netherlands",name_long:"Netherlands"}},{arcs:[[507,508]],type:"Polygon",properties:{id:"PRT",name:"Portugal",name_long:"Portugal"}},{arcs:[[-245,509,-508,510]],type:"Polygon",properties:{id:"ESP",name:"Spain",name_long:"Spain"}},{arcs:[[511,512]],type:"Polygon",properties:{id:"IRL",name:"Ireland",name_long:"Ireland"}},{arcs:[[513]],type:"Polygon",properties:{id:"NCL",name:"New Caledonia",name_long:"New Caledonia"}},{arcs:[[[514]],[[515]],[[516]],[[517]],[[518]]],type:"MultiPolygon",properties:{id:"SLB",name:"Solomon Is.",name_long:"Solomon Islands"}},{arcs:[[[519]],[[520]]],type:"MultiPolygon",properties:{id:"NZL",name:"New Zealand",name_long:"New Zealand"}},{arcs:[[[521]],[[522]]],type:"MultiPolygon",properties:{id:"AUS",name:"Australia",name_long:"Australia"}},{arcs:[[523]],type:"Polygon",properties:{id:"LKA",name:"Sri Lanka",name_long:"Sri Lanka"}},{arcs:[[[-62,-152,-396,-150,-394,524,-389,-383,-388,-404,-406,-402,-407,-400,-411,-413,-417,-418]],[[525]]],type:"MultiPolygon",properties:{id:"CHN",name:"China",name_long:"China"}},{arcs:[[526]],type:"Polygon",properties:{id:"TWN",name:"Taiwan",name_long:"Taiwan"}},{arcs:[[[-243,-503,-454,527,528]],[[529]],[[530]]],type:"MultiPolygon",properties:{id:"ITA",name:"Italy",name_long:"Italy"}},{arcs:[[[-477,531]],[[532]]],type:"MultiPolygon",properties:{id:"DNK",name:"Denmark",name_long:"Denmark"}},{arcs:[[[-513,533]],[[534]]],type:"MultiPolygon",properties:{id:"GBR",name:"United Kingdom",name_long:"United Kingdom"}},{arcs:[[535]],type:"Polygon",properties:{id:"ISL",name:"Iceland",name_long:"Iceland"}},{arcs:[[[-138,536,-424,-432,537]],[[-422,-429]]],type:"MultiPolygon",properties:{id:"AZE",name:"Azerbaijan",name_long:"Azerbaijan"}},{arcs:[[-139,-538,-431,-492,538]],type:"Polygon",properties:{id:"GEO",name:"Georgia",name_long:"Georgia"}},{arcs:[[[539]],[[540]],[[541]],[[542]],[[543]],[[544]],[[545]]],type:"MultiPolygon",properties:{id:"PHL",name:"Philippines",name_long:"Philippines"}},{arcs:[[[-82,546,547,548]],[[-378,549]]],type:"MultiPolygon",properties:{id:"MYS",name:"Malaysia",name_long:"Malaysia"}},{arcs:[[-548,550]],type:"Polygon",properties:{id:"BRN",name:"Brunei",name_long:"Brunei Darussalam"}},{arcs:[[-453,-462,-502,551,-528]],type:"Polygon",properties:{id:"SVN",name:"Slovenia",name_long:"Slovenia"}},{arcs:[[-146,552,-433,-173]],type:"Polygon",properties:{id:"FIN",name:"Finland",name_long:"Finland"}},{arcs:[[-445,-463,-458,553,-448]],type:"Polygon",properties:{id:"SVK",name:"Slovakia",name_long:"Slovakia"}},{arcs:[[-449,-554,-457,-479]],type:"Polygon",properties:{id:"CZE",name:"Czechia",name_long:"Czech Republic"}},{arcs:[[-127,554,555,556]],type:"Polygon",properties:{id:"ERI",name:"Eritrea",name_long:"Eritrea"}},{arcs:[[[557]],[[558]],[[559]]],type:"MultiPolygon",properties:{id:"JPN",name:"Japan",name_long:"Japan"}},{arcs:[[-98,-206,-196]],type:"Polygon",properties:{id:"PRY",name:"Paraguay",name_long:"Paraguay"}},{arcs:[[-369,560,561]],type:"Polygon",properties:{id:"YEM",name:"Yemen",name_long:"Yemen"}},{arcs:[[-350,-366,-360,562,-358,563,-356,-370,-562,564]],type:"Polygon",properties:{id:"SAU",name:"Saudi Arabia",name_long:"Saudi Arabia"}},{arcs:[[[565]],[[566]],[[567]],[[568]],[[569]],[[570]],[[571]],[[572]]],type:"MultiPolygon",properties:{id:"ATA",name:"Antarctica",name_long:"Antarctica"}},{arcs:[[573,574]],type:"Polygon",properties:{id:"CYN",name:"N. Cyprus",name_long:"Northern Cyprus"}},{arcs:[[-575,575]],type:"Polygon",properties:{id:"CYP",name:"Cyprus",name_long:"Cyprus"}},{arcs:[[-16,576,-345]],type:"Polygon",properties:{id:"MAR",name:"Morocco",name_long:"Morocco"}},{arcs:[[-125,577,578,-333,579]],type:"Polygon",properties:{id:"EGY",name:"Egypt",name_long:"Egypt"}},{arcs:[[-124,-133,-286,-347,-344,580,-578]],type:"Polygon",properties:{id:"LBY",name:"Libya",name_long:"Libya"}},{arcs:[[-115,-120,581,-128,-557,582,583]],type:"Polygon",properties:{id:"ETH",name:"Ethiopia",name_long:"Ethiopia"}},{arcs:[[-556,584,585,-583]],type:"Polygon",properties:{id:"DJI",name:"Djibouti",name_long:"Djibouti"}},{arcs:[[-116,-584,-586,586]],type:"Polygon",properties:{id:"SOL",name:"Somaliland",name_long:"Somaliland"}},{arcs:[[-12,587,-111,588,-118]],type:"Polygon",properties:{id:"UGA",name:"Uganda",name_long:"Uganda"}},{arcs:[[-11,-328,-112,-588]],type:"Polygon",properties:{id:"RWA",name:"Rwanda",name_long:"Rwanda"}},{arcs:[[-499,589,590]],type:"Polygon",properties:{id:"BIH",name:"Bosnia and Herz.",name_long:"Bosnia and Herzegovina"}},{arcs:[[-484,-489,-497,591,592]],type:"Polygon",properties:{id:"MKD",name:"North Macedonia",name_long:"North Macedonia"}},{arcs:[[-460,-467,-485,-593,593,594,-590,-498]],type:"Polygon",properties:{id:"SRB",name:"Serbia",name_long:"Serbia"}},{arcs:[[-495,595,-500,-591,-595,596]],type:"Polygon",properties:{id:"MNE",name:"Montenegro",name_long:"Montenegro"}},{arcs:[[-496,-597,-594,-592]],type:"Polygon",properties:{id:"KOS",name:"Kosovo",name_long:"Kosovo"}},{arcs:[[597]],type:"Polygon",properties:{id:"TTO",name:"Trinidad and Tobago",name_long:"Trinidad and Tobago"}},{arcs:[[-110,-313,-129,-582,-119,-589]],type:"Polygon",properties:{id:"SDS",name:"S. Sudan",name_long:"South Sudan"}}]}}};
+
+    const mapElement = document.getElementById("nordicMap");
+    const mapCountries = feature(worldTopology, worldTopology.objects.features).features;
+    const visibleCountryIds = new Set(["DNK", "SWE", "NOR", "FIN", "DEU", "POL", "EST", "LVA", "LTU"]);
+    const focusCountryIds = new Set(["DNK", "SWE"]);
+    const visibleCountries = mapCountries.filter((country) => visibleCountryIds.has(country.properties.id));
+    const routeFrame = {
+      type: "MultiPoint",
+      coordinates: [[7.1, 54.1], [20.5, 54.1], [20.5, 60.75], [7.1, 60.75]]
+    };
+    const mapLocations = [
+      { name: "Billund", note: "2 nights · LEGO finish", coordinates: [9.1157, 55.7284], offset: [-18, -24], mobileOffset: [12, -20] },
+      { name: "Copenhagen / CPH", note: "final night + SK935", coordinates: [12.6508, 55.6181], offset: [-62, 33], mobileOffset: [-12, 44] },
+      { name: "Malmö / Hyllie", note: "Baltzar + ECCV", coordinates: [12.9764, 55.5631], offset: [54, 28], mobileOffset: [22, 38] },
+      { name: "Lund", note: "easy family day", coordinates: [13.1870, 55.7047], offset: [50, -30], mobileOffset: [22, -28] },
+      { name: "Stockholm", note: "first 3 nights", coordinates: [18.0686, 59.3293], offset: [18, -24], mobileOffset: [-12, -18], stockholm: true }
+    ];
+    const coreRoute = {
+      type: "LineString",
+      coordinates: [[12.9764, 55.5631], [9.1157, 55.7284], [12.6508, 55.6181]]
+    };
+    const stockholmRoute = {
+      type: "LineString",
+      coordinates: [[18.0686, 59.3293], [12.9764, 55.5631]]
+    };
+    const returnFlightRoute = {
+      type: "LineString",
+      coordinates: [[12.6508, 55.6181], [17.9186, 59.6519]]
+    };
+
+    function drawNordicMap() {
+      const width = Math.max(320, mapElement.clientWidth || 800);
+      const height = Math.max(420, mapElement.clientHeight || 620);
+      const compact = width < 620;
+      const svg = d3.select(mapElement);
+      svg.selectAll("g").remove();
+      svg.attr("viewBox", `0 0 ${width} ${height}`);
+
+      const projection = d3.geoMercator().fitExtent(
+        compact ? [[22, 34], [width - 22, height - 34]] : [[42, 34], [width - 38, height - 36]],
+        routeFrame
+      );
+      const path = d3.geoPath(projection);
+      const root = svg.append("g");
+      const locationOffset = (location) => compact ? location.mobileOffset : location.offset;
+
+      root.append("g")
+        .selectAll("path")
+        .data(visibleCountries)
+        .join("path")
+        .attr("class", (country) => `map-country${focusCountryIds.has(country.properties.id) ? " is-focus" : ""}`)
+        .attr("d", path);
+
+      root.append("path")
+        .datum(coreRoute)
+        .attr("class", "map-route-core")
+        .attr("d", path);
+
+      root.append("path")
+        .datum(stockholmRoute)
+        .attr("class", "map-route-stockholm")
+        .attr("d", path);
+
+      root.append("path")
+        .datum(returnFlightRoute)
+        .attr("class", "map-route-flight")
+        .attr("d", path);
+
+      const locations = root.append("g")
+        .selectAll("g")
+        .data(mapLocations)
+        .join("g")
+        .attr("class", (location) => `map-location${location.stockholm ? " is-stockholm" : ""}`)
+        .attr("transform", (location) => `translate(${projection(location.coordinates).join(",")})`);
+
+      locations.append("line")
+        .attr("class", "map-leader")
+        .attr("x2", (location) => locationOffset(location)[0])
+        .attr("y2", (location) => locationOffset(location)[1]);
+
+      locations.append("circle").attr("class", "map-marker-halo").attr("r", 9);
+      locations.append("circle").attr("class", "map-marker-core").attr("r", 4.5);
+
+      const labels = locations.append("text")
+        .attr("class", "map-label")
+        .attr("x", (location) => locationOffset(location)[0] + (locationOffset(location)[0] < 0 ? -5 : 5))
+        .attr("y", (location) => locationOffset(location)[1])
+        .attr("text-anchor", (location) => locationOffset(location)[0] < 0 ? "end" : "start");
+
+      labels.append("tspan")
+        .attr("x", function(location) { return d3.select(this.parentNode).attr("x"); })
+        .text((location) => location.name);
+      labels.append("tspan")
+        .attr("class", "map-label-note")
+        .attr("x", function(location) { return d3.select(this.parentNode).attr("x"); })
+        .attr("dy", 14)
+        .text((location) => location.note);
+    }
+
+    drawNordicMap();
+    const mapObserver = new ResizeObserver(drawNordicMap);
+    mapObserver.observe(mapElement);
+  </script>
+
+
+</body></html>


### PR DESCRIPTION
## What changed

Adds the privacy-reviewed Scandi ECCV 2026 family trip page under an opaque, unlisted path matching the existing Asia-trip convention.

## Privacy

The public page omits traveler names, reservation identifiers, seat assignments, account links, personal contact information, exact booking charges, and the conference paper identity. It includes crawler exclusion metadata and relies on the repository-wide `/unlisted/` robots rule.

## Validation

- JavaScript syntax checked for both classic and module scripts
- Duplicate HTML IDs checked
- Targeted private-token scan passed
- External-resource scan confirmed there are no missing local assets
- `git diff --check` passed