### PR TITLE
Add Billund and Copenhagen hotel and rail plan

### DIFF
--- a/site/unlisted/scandi-eccv-2026-2a885349b7d5aecf/trip.htm
+++ b/site/unlisted/scandi-eccv-2026-2a885349b7d5aecf/trip.htm
@@ -3998,6 +3998,54 @@
 
         <div class="program-watch">
           <div>
+            <p class="eyebrow">Billund hotel decision</p>
+            <h3>Stay at the park gate unless space matters more than speed.</h3>
+            <p>No date-specific availability is asserted here. Search September 13–15 for exactly two adults and two children, then compare the all-in flexible rate and the actual four-person bed setup.</p>
+          </div>
+          <div class="watch-grid">
+            <div class="watch-topic"><strong>1 · Hotel LEGOLAND · best fit</strong><span>Zero-friction partial park day, breakfast, play spaces, and four-bed themed rooms; LEGO House is about 900 m away. Expect a premium price, a very themed atmosphere, and no kitchen or laundry.</span></div>
+            <div class="watch-topic"><strong>2 · The Lodge Billund · best quieter alternative</strong><span>Several official room categories allow four guests, with a calmer, more adult-friendly feel. Confirm the exact sofa-bed layout and the post-summer local transport plan before paying.</span></div>
+            <div class="watch-topic"><strong>3 · Refborg Hotel · best for LEGO House + town</strong><span>The Family Double officially sleeps four and includes breakfast; the central location is good for dinner and LEGO House. It is about 1.1 km from LEGOLAND and has no pool.</span></div>
+            <div class="watch-topic"><strong>4 · Lalandia Classic 4 · best space</strong><span>Two bedrooms, kitchen, washer, parking, and Aquadome access make it the rainy-day winner. Linen and utilities are extra, and a spread-out holiday village adds too much overhead for two nights without a car.</span></div>
+            <div class="watch-topic"><strong>Splurge · LEGOLAND Castle Hotel</strong><span>The strongest children’s “wow” option beside the park, with immersive rooms and breakfast. It is usually difficult to justify over Hotel LEGOLAND for a short stay unless the hotel itself is part of the attraction.</span></div>
+            <div class="watch-topic"><strong>Booking filter</strong><span>Prioritize a true four-person room, breakfast, free luggage storage before check-in, and a flexible rate. For this itinerary, proximity is worth more than a pool or a kitchen.</span></div>
+          </div>
+        </div>
+
+        <div class="program-watch">
+          <div>
+            <p class="eyebrow">Copenhagen final night</p>
+            <h3>Stay in the city; a 12:45 flight does not require an airport hotel.</h3>
+            <p>Search September 15–16 for four guests. Plan to leave central Copenhagen around 09:15–09:30 for a generous airport buffer, and choose Kastrup only if the family values minimum morning friction over one last city evening.</p>
+          </div>
+          <div class="watch-grid">
+            <div class="watch-topic"><strong>1 · Scandic Spectrum · best overall</strong><span>Modern waterfront base with official four-person family rooms and larger Junior Suites. It balances an enjoyable final evening with a manageable trip to Central Station; the standard room’s 120 cm sofa bed may feel tight for two children.</span></div>
+            <div class="watch-topic"><strong>2 · Tivoli Hotel · best kid amenity</strong><span>Family rooms sleep four, connecting rooms add real separation, and the indoor pool is useful after a transfer day. Despite the name, it is not at Tivoli Gardens or directly beside Central Station.</span></div>
+            <div class="watch-topic"><strong>3 · Scandic Copenhagen · best simple city base</strong><span>The Standard Family Four is a roomier 26 m² and the lakes/Tivoli area gives the final evening more city character. It is a conventional large hotel and still needs a short walk or local ride to the airport train.</span></div>
+            <div class="watch-topic"><strong>Fallback · Scandic CPH Strandpark</strong><span>Official family rooms, airport proximity, and a hotel shuttle make departure easy. It sacrifices the Copenhagen encore, so use it only if the central options are poor value or the September 15 transfer becomes late.</span></div>
+          </div>
+        </div>
+
+        <div class="program-watch">
+          <div>
+            <p class="eyebrow">Rail versus rental car</p>
+            <h3>Train everywhere—plus one Billund bus or taxi.</h3>
+            <p>Billund has no railway station. The clean public-transport route is Malmö C → Copenhagen H → Vejle by train, then bus 43 or a taxi to the hotel. This avoids an international one-way rental, car-seat logistics, fuel, parking, and two Great Belt crossings.</p>
+          </div>
+          <div class="watch-grid">
+            <div class="watch-topic"><strong>Sep 7 · book now</strong><span>Reserve a direct SJ X 2000 from Stockholm C to Malmö C with four assigned seats together. Favor a direct mid-morning departure that arrives near Baltzar’s 15:00 check-in; do not accept a 05:22 start merely to save money.</span></div>
+            <div class="watch-topic"><strong>Sep 13 · book now</strong><span>Buy Malmö → Copenhagen separately through Skånetrafiken, then a flexible DSB Orange Fri Copenhagen H → Vejle ticket. Reserve four adjacent seats and allow 30–45 minutes in Copenhagen.</span></div>
+            <div class="watch-topic"><strong>Sep 15 · book now</strong><span>Use bus or taxi Billund → Vejle, then DSB InterCityLyn to Copenhagen H. Orange Fri is the best balance of advance savings and flexibility; reserve seats for all four even though the children may travel free with the adults.</span></div>
+            <div class="watch-topic"><strong>Buy later</strong><span>Arlanda Express, Malmö–Hyllie conference trains, the Öresund cross-border local leg, and the Vejle–Billund bus do not need scarce-train-style advance reservations. Check the final journeys in the operator apps.</span></div>
+            <div class="watch-topic"><strong>When a car wins</strong><span>Rent only if the plan changes to Lalandia plus a driving day at Givskud or Jelling. A Copenhagen round-trip rental adds two bridge tolls and is poor value for Hotel LEGOLAND + LEGO House.</span></div>
+            <div class="watch-topic"><strong>Best luggage shortcut</strong><span>If the Sunday bus timing is clumsy, use a taxi from Vejle to Hotel LEGOLAND instead of renting for two days. Ask the hotel to hold bags before check-in so the partial park day remains intact.</span></div>
+          </div>
+        </div>
+
+        <p class="decision-note"><strong>Current booking recommendation:</strong> hold a four-bed room at Hotel LEGOLAND for September 13–15 and a Family Four or Junior Suite at Scandic Spectrum for September 15. Then book the direct SJ train and both DSB long-distance legs. Keep The Lodge and Tivoli Hotel as the respective backups.</p>
+
+        <div class="program-watch">
+          <div>
             <p class="eyebrow">Beyond the bricks</p>
             <h3>Five good Billund-area alternatives</h3>
             <p>Pick one only. The strongest choice depends on weather, transport, and whether this is a half-day before Copenhagen or a true extra day.</p>
@@ -4054,13 +4102,13 @@
             <label class="check-item"><input type="checkbox" data-check="flights" checked disabled><span class="check-copy"><strong>SAS flights booked</strong><span>SK936 + SK1426 outbound and SK935 nonstop home are confirmed for four travelers. Approximate paid total: $6.1k.</span></span><span class="priority later">Booked</span></label>
             <label class="check-item"><input type="checkbox" data-check="malmo-hotel" checked disabled><span class="check-copy"><strong>Home Hotel Baltzar booked · Sep 7–13</strong><span>Junior Suite for four · approximately $2.8k · free cancellation until Sep 5 at 11:59pm local. Reservation number redacted.</span></span><span class="priority later">Booked</span></label>
             <label class="check-item"><input type="checkbox" data-check="stockholm-hotel" checked disabled><span class="check-copy"><strong>Scandic Continental Master Suite booked · Sep 4–7</strong><span>Family of four · about $1.5k · non-refundable; reservation and payment details redacted.</span></span><span class="priority later">Booked</span></label>
-            <label class="check-item"><input type="checkbox" data-check="billund-hotel"><span class="check-copy"><strong>Hold Billund for Sep 13–15</strong><span>Choose a base that will hold bags before check-in so the partial September 13 LEGOLAND day remains usable.</span></span><span class="priority">Now</span></label>
-            <label class="check-item"><input type="checkbox" data-check="cph-hotel"><span class="check-copy"><strong>Hold Copenhagen for Sep 15</strong><span>Central Copenhagen is more enjoyable; Kastrup is safer if the family wants a frictionless SK935 morning.</span></span><span class="priority">Now</span></label>
-            <label class="check-item"><input type="checkbox" data-check="transfer"><span class="check-copy"><strong>Book Stockholm → Malmö; price Malmö → Billund</strong><span>SJ direct trains take about 4½ hours; current family fares are dynamic. Compare driver and one-way rental for September 13.</span></span><span class="priority soon">Soon</span></label>
+            <label class="check-item"><input type="checkbox" data-check="billund-hotel"><span class="check-copy"><strong>Hold Hotel LEGOLAND · Sep 13–15</strong><span>Search a four-bed themed room first; compare The Lodge and Refborg only if the rate or bed setup is materially better. Confirm early luggage storage.</span></span><span class="priority">Now</span></label>
+            <label class="check-item"><input type="checkbox" data-check="cph-hotel"><span class="check-copy"><strong>Hold Scandic Spectrum · Sep 15</strong><span>Price a Family Four and Junior Suite; use Tivoli Hotel as the pool-forward backup. The 12:45 flight does not require a Kastrup stay.</span></span><span class="priority">Now</span></label>
+            <label class="check-item"><input type="checkbox" data-check="transfer"><span class="check-copy"><strong>Book the three scarce train legs</strong><span>Direct SJ Stockholm → Malmö plus DSB Copenhagen → Vejle and Vejle → Copenhagen. Prefer Orange Fri and reserve four adjacent seats; no rental car by default.</span></span><span class="priority">Now</span></label>
             <label class="check-item"><input type="checkbox" data-check="lego"><span class="check-copy"><strong>Book LEGOLAND + LEGO House entries</strong><span>Use a partial LEGOLAND day September 13 and LEGO House September 14. Both anchors are closed September 15.</span></span><span class="priority soon">Soon</span></label>
             <label class="check-item"><input type="checkbox" data-check="eccv"><span class="check-copy"><strong>Register and lock the Sep 8–9 workshop plan</strong><span>Primary plan: Multimodal Digital Agents on Tuesday and World Models for Embodied AI on Wednesday.</span></span><span class="priority">Now</span></label>
             <label class="check-item"><input type="checkbox" data-check="poster"><span class="check-copy"><strong>Capture the poster's exact assignment</strong><span>Date, session, time, room, and board are still TBA; watch the author inbox and official program. Paper identity is redacted publicly.</span></span><span class="priority soon">Soon</span></label>
-            <label class="check-item"><input type="checkbox" data-check="rail"><span class="check-copy"><strong>Install rail apps and plan airport tickets</strong><span>Use Skånetrafiken / Öresundståg for southern Sweden and cross-border travel; carry valid ID.</span></span><span class="priority later">Later</span></label>
+            <label class="check-item"><input type="checkbox" data-check="rail"><span class="check-copy"><strong>Install local rail + bus apps</strong><span>Use Skånetrafiken for Malmö/Öresund, DSB for Denmark, and Rejseplanen for the Vejle–Billund bus. Carry valid ID.</span></span><span class="priority later">Later</span></label>
             <label class="check-item"><input type="checkbox" data-check="dinner"><span class="check-copy"><strong>Pick one Stockholm classic dinner</strong><span>Tradition in Gamla Stan is a straightforward first-timer option; keep the other meals flexible.</span></span><span class="priority later">Later</span></label>
           </div>
         </div>
@@ -4110,7 +4158,9 @@
               <li><a href="https://swedish-rails-en-prod.cxoneexpert.ai/Tickets_and_purchase/Does_SJ_have_any_discount_for_children%3F" target="_blank" rel="noreferrer">SJ family discount details</a></li>
               <li><a href="https://swedish-rails-en-prod.cxoneexpert.ai/Tickets_and_purchase/When_does_SJ_release_their_tickets%3F" target="_blank" rel="noreferrer">SJ ticket release window</a></li>
               <li><a href="https://www.dsb.dk/en/kundeservice/sporgsmal-og-svar/does-billund-have-a-train-station/" target="_blank" rel="noreferrer">DSB: Billund–Vejle bus connection</a></li>
-              <li><a href="https://www.dsb.dk/en/train-rides-in-denmark/vejle-copenhagen/" target="_blank" rel="noreferrer">DSB: Vejle–Copenhagen train</a></li>
+              <li><a href="https://www.dsb.dk/togture-i-danmark/kobenhavn-vejle/" target="_blank" rel="noreferrer">DSB: Copenhagen–Vejle InterCityLyn</a></li>
+              <li><a href="https://www.dsb.dk/en/find-produkter-og-services/orange-fri/" target="_blank" rel="noreferrer">DSB Orange Fri flexibility, child, and sale-window rules</a></li>
+              <li><a href="https://www.storebaelt.dk/en/prices-and-discounts/private/" target="_blank" rel="noreferrer">Great Belt 2026 car tolls</a></li>
             </ul>
           </div>
           <div class="source-group">
@@ -4135,6 +4185,16 @@
               <li><a href="https://www.bestwestern.se/hotell/best-western-plus-hotel-noble-house-88158" target="_blank" rel="noreferrer">Noble House family rooms, breakfast, and kids' corner</a></li>
               <li><a href="https://www.themorehotel.se/en/mazetti/hotellrum-mazetti/" target="_blank" rel="noreferrer">Mazetti room capacities + kitchens</a></li>
               <li><a href="https://www.scandichotels.com/en/hotels/scandic-triangeln" target="_blank" rel="noreferrer">Scandic Triangeln family rooms</a></li>
+              <li><a href="https://www.legoland.dk/en/short-break/you-can-stay-here/hotel-legoland/" target="_blank" rel="noreferrer">Hotel LEGOLAND themed rooms and included breakfast</a></li>
+              <li><a href="https://www.legoland.dk/en/short-break/you-can-stay-here/hotel-legoland/themed-rooms/park-view-room/" target="_blank" rel="noreferrer">Hotel LEGOLAND Park View four-bed room</a></li>
+              <li><a href="https://thelodge.dk/rooms/" target="_blank" rel="noreferrer">The Lodge Billund rooms for up to four</a></li>
+              <li><a href="https://www.bestwestern.com/en_US/book/billund/hotel-rooms/refborg-hotel-billund-sure-hotel-collection-by-best-western/propertyCode.96612.html" target="_blank" rel="noreferrer">Refborg Hotel Family Double occupancy</a></li>
+              <li><a href="https://www.lalandia.dk/en/billund/holiday-homes/classic-4" target="_blank" rel="noreferrer">Lalandia Classic 4 space and inclusions</a></li>
+              <li><a href="https://www.scandichotels.com/en/hotels/scandic-spectrum" target="_blank" rel="noreferrer">Scandic Spectrum family rooms and suites</a></li>
+              <li><a href="https://www.tivolihotel.com/rooms-and-suites" target="_blank" rel="noreferrer">Tivoli Hotel family and connecting rooms</a></li>
+              <li><a href="https://www.tivolihotel.com/facilities-and-services/swimming-pool-and-sauna" target="_blank" rel="noreferrer">Tivoli Hotel indoor pool</a></li>
+              <li><a href="https://www.scandichotels.com/en/hotels/scandic-copenhagen" target="_blank" rel="noreferrer">Scandic Copenhagen Standard Family Four</a></li>
+              <li><a href="https://www.scandichotels.com/en/hotels/scandic-cph-strandpark" target="_blank" rel="noreferrer">Scandic CPH Strandpark family rooms</a></li>
             </ul>
           </div>
           <div class="source-group">
@@ -4167,7 +4227,7 @@
           <div class="source-group">
             <h3>Important caveats</h3>
             <ul>
-              <li>Home Hotel Baltzar and Scandic Continental are confirmed; availability for the remaining Billund and Copenhagen stays is not asserted.</li>
+              <li>Home Hotel Baltzar and Scandic Continental are confirmed; the Billund and Copenhagen hotel rankings compare official room types and locations, not live September 2026 inventory or rates.</li>
               <li>The Scandic Continental Master Suite rate is non-refundable; contact the property in advance if arrival may be after midnight.</li>
               <li>Drive time and door-to-door commute times are planning estimates.</li>
               <li>The main-conference program and poster session assignment are not yet public.</li>
@@ -4176,7 +4236,7 @@
             </ul>
           </div>
         </div>
-        <p class="as-of">Public planning edition updated August 18, 2026. The SAS itinerary, Scandic Continental stay, and Home Hotel Baltzar stay are confirmed, with approximate combined booked costs of $10.4k. Passenger names, reservation identifiers, assigned seats, account credits, payment details, and the conference paper identity are omitted. A live SJ search for September 7 showed direct Stockholm–Malmö X 2000 journeys around 4h31–4h33 and family fares from SEK 2,196. The official calendars show both LEGO anchors open during September 13–14 and closed September 15.</p>
+        <p class="as-of">Public planning edition updated August 18, 2026. The SAS itinerary, Scandic Continental stay, and Home Hotel Baltzar stay are confirmed, with approximate combined booked costs of $10.4k. Passenger names, reservation identifiers, assigned seats, account credits, payment details, and the conference paper identity are omitted. Hotel LEGOLAND and Scandic Spectrum are the current unbooked lodging recommendations. The transport default is rail, with a Vejle–Billund bus or taxi rather than a rental car.</p>
       </div>
     </section><section id="archive" class="archive-section">
       <div class="wrap">
@@ -4465,6 +4525,10 @@ CURRENT RECOMMENDATION
 • Sunday September 13: partial LEGOLAND day, open 10:00–18:00
 • Monday September 14: LEGO House, 10:00–16:00
 • Transfer Billund → Copenhagen September 15 and sleep there before SK935
+• Billund hotel first choice: a four-bed room at Hotel LEGOLAND; The Lodge is the quieter backup
+• Copenhagen first choice: Scandic Spectrum Family Four or Junior Suite; Tivoli Hotel is the pool-forward backup
+• Transport verdict: train throughout, with bus 43 or taxi between Vejle and Billund; do not rent a car unless adding Lalandia plus a driving day
+• Book now: direct SJ Stockholm → Malmö and DSB Orange Fri Copenhagen ↔ Vejle, with four adjacent reserved seats
 
 ECCV ATTENDANCE PLAN
 • Sep 8 primary: Multimodal Digital Agents, full day
@@ -4493,15 +4557,15 @@ FLIGHTS
 OPEN DECISIONS
 • Preferred September 7 Stockholm → Malmö departure and live fare
 • Confirm Baltzar sofa-bed preparation and any property-collected mandatory fees before Sep 5
-• Billund and Copenhagen family rooms
-• Sep 13 Malmö → Billund transfer method
+• Exact Billund and Copenhagen room types, rates, and cancellation terms
+• Preferred direct SJ departure and both DSB Orange Fri departure times
 • Exact ECCV poster assignment and main-program selections
 
 CHECKLIST ITEMS COMPLETED ON THIS DEVICE
 ${selectedChecks.length ? selectedChecks.map((item) => `• ${item}`).join("\n") : "• None yet"}
 
 RESEARCH CHECKED
-August 18, 2026. Flights, Scandic Continental, and Home Hotel Baltzar are confirmed. The Stockholm comparison is archived because the selected Master Suite rate is prepaid and non-refundable.`;
+August 18, 2026. Flights, Scandic Continental, and Home Hotel Baltzar are confirmed. Billund/Copenhagen lodging and the western rail plan were refreshed from official hotel and train sources; live room inventory and rates are not asserted.`;
     }
 
     function openExportModal() {


### PR DESCRIPTION
## What changed

- ranks family hotel options in Billund and Copenhagen with practical pros and cons
- recommends rail throughout, with a Vejle–Billund bus or taxi for the last mile
- adds the exact long-distance train tickets to book now and updates the planning checklist
- preserves the public redaction boundary

## Why

The remaining open decisions are the two western hotel stays and how to travel between Malmö, Billund, and Copenhagen.

## Checks

- public source matches the deployment copy
- HTML structure checked after excluding embedded SVG and module script content from the legacy validator
- inline module JavaScript syntax checked
- privacy scan found no private reservation identifiers