### PR TITLE
Add Denmark road-trip options

### DIFF
--- a/site/unlisted/scandi-eccv-2026-2a885349b7d5aecf/trip.htm
+++ b/site/unlisted/scandi-eccv-2026-2a885349b7d5aecf/trip.htm
@@ -2,7 +2,7 @@
 <html lang="en"><head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="description" content="A public, privacy-safe September 2026 family trip guide for Stockholm, ECCV in Malmö, Billund, and Copenhagen.">
+  <meta name="description" content="A public, privacy-safe September 2026 family trip guide for Stockholm, ECCV in Malmö, and a LEGOLAND–Aarhus road trip across Denmark.">
   <meta name="robots" content="noindex,nofollow,noarchive,noimageindex">
   <meta name="googlebot" content="noindex,nofollow,noarchive,noimageindex">
   <meta name="referrer" content="no-referrer">
@@ -2942,8 +2942,8 @@
   <header class="hero">
     <div class="hero-copy-panel">
       <p class="kicker">Public planning edition · September 2026</p>
-      <h1>A Scandi ECCV 2026<span>Stockholm → Malmö → Billund · nonstop home</span></h1>
-      <p class="hero-deck">A north-to-west Nordic family trip built around ECCV: three nights in Stockholm, a rail-simple conference week in central Malmö, then LEGO country and a Copenhagen launch pad for the nonstop flight home.</p>
+      <h1>A Scandi ECCV 2026<span>Stockholm → Malmö → LEGOLAND + Aarhus · nonstop home</span></h1>
+      <p class="hero-deck">A north-to-west Nordic family trip built around ECCV: three nights in Stockholm, a rail-simple conference week in central Malmö, then a compact Denmark road trip with LEGOLAND, Aarhus, and an airport-side launch pad for the nonstop flight home.</p>
       <div class="hero-meta" aria-label="Trip facts">
         <span class="pill">September 3–16, 2026</span>
         <span class="pill">Family of four · two young children</span>
@@ -2957,7 +2957,7 @@
       </div>
     </div>
     <div class="hero-photo" role="img" aria-label="The Öresund Bridge connecting Denmark and Sweden">
-      <div class="photo-note">The organizing idea: fly north first, take the train to Malmö, then finish west through Billund and Copenhagen.</div>
+      <div class="photo-note">The organizing idea: fly north first, take the train to Malmö, then make a short Denmark road loop through LEGOLAND and Aarhus.</div>
     </div>
   </header>
 
@@ -2971,7 +2971,7 @@
       <a href="#base">Malmö commute</a>
       <a href="#conference">ECCV plan</a>
       <a href="#family">Malmö family days</a>
-      <a href="#billund">Billund + CPH</a>
+      <a href="#billund">Denmark road trip</a>
       <a href="#book">Book next</a>
       <a href="#sources">Sources</a>
       <a href="#archive">Decision archive</a>
@@ -2984,7 +2984,7 @@
         <div class="section-head">
           <div>
             <p class="eyebrow">The short answer</p>
-            <h2>Stockholm first. Malmö for ECCV. Billund last. Nonstop home.</h2>
+            <h2>Stockholm first. Malmö for ECCV. Then a LEGOLAND–Aarhus loop.</h2>
           </div>
           <p>The reversed September 3–16 shape is stronger for the family: the only flight connection happens on arrival with a sensible buffer, Stockholm gets two full days, and the final night protects SK935 nonstop to SFO.</p>
         </div>
@@ -3009,7 +3009,7 @@
               <div class="stat-label">Trip hinge</div>
               <div class="stat-value">Sep 13</div>
             </div>
-            <div class="stat-note">Stay in Malmö through Saturday night, then transfer west Sunday morning. Billund becomes two nights, with a partial park day plus one full LEGO day.</div>
+            <div class="stat-note">Stay in Malmö through Saturday night, collect a car at Copenhagen Airport Sunday morning, visit LEGOLAND, then sleep two nights in Aarhus.</div>
           </article>
           <article class="card stat-card">
             <div>
@@ -3024,7 +3024,7 @@
           <div class="recommendation-mark" aria-hidden="true">R</div>
           <div>
             <h3>Recommended working plan</h3>
-            <p>The SAS flights, Scandic Continental Master Suite, and Malmö hotel are locked: SK936 and SK1426 to Stockholm, Scandic Continental September 4–7, Home Hotel Baltzar September 7–13, then SK935 nonstop home.</p>
+            <p>The booked flights and first nine hotel nights are locked. For September 13–16, the best working plan is LEGOLAND on Sunday, two nights in Aarhus, an optional Funen stop Tuesday, and a final night beside Copenhagen Airport.</p>
           </div>
           <span class="tag blue">Best balance</span>
         </div>
@@ -3038,25 +3038,25 @@
             <p class="eyebrow">Confirmed trip framework</p>
             <h2>The flights and nine booked hotel nights anchor the calendar.</h2>
           </div>
-          <p>This is the operating itinerary. Earlier route and lodging comparisons have moved to the decision archive; the remaining open choices are the western transfer and final Billund–Copenhagen stays.</p>
+          <p>The booked framework is fixed through Malmö. The final three nights are now an active Denmark road-trip decision: LEGOLAND is the constraint; Aarhus, LEGO House, and the final-night location are the variables.</p>
         </div>
 
-        <div class="scenario-controls" role="group" aria-label="Archived itinerary scenarios" hidden>
-          <button class="scenario-button" type="button" data-scenario="reverse" aria-pressed="true">Recommended · Sep 3–16</button>
-          <button class="scenario-button" type="button" data-scenario="posterSafe" aria-pressed="false">Leave Sep 12 · 3 Billund nights</button>
-          <button class="scenario-button" type="button" data-scenario="billundLate" aria-pressed="false">3 Billund nights · risky return</button>
+        <div class="scenario-controls" role="group" aria-label="Denmark road-trip scenarios">
+          <button class="scenario-button" type="button" data-scenario="aarhusLoop" aria-pressed="true">Recommended · 2 Aarhus nights</button>
+          <button class="scenario-button" type="button" data-scenario="legoHouse" aria-pressed="false">LEGO House · 3 one-night stays</button>
+          <button class="scenario-button" type="button" data-scenario="billundCalm" aria-pressed="false">Calmest · 2 Billund nights</button>
         </div>
 
         <div class="scenario-shell" aria-live="polite">
           <div class="scenario-top">
             <div>
               <span class="tag blue" id="scenarioDates">Sep 3–16 · about 8 school days</span>
-              <h3 id="scenarioTitle">Stockholm, ECCV, Billund, Copenhagen</h3>
-              <p id="scenarioSummary">Three Stockholm nights, six Malmö nights, two Billund nights, and one Copenhagen night before the nonstop home.</p>
+              <h3 id="scenarioTitle">Stockholm, ECCV, LEGOLAND, Aarhus, CPH</h3>
+              <p id="scenarioSummary">Keep the booked first nine nights, use LEGOLAND on Sunday, sleep twice in Aarhus, and finish beside Copenhagen Airport.</p>
             </div>
             <div class="scenario-verdict">
-              <strong id="scenarioVerdictTitle">Locked framework</strong>
-              <span id="scenarioVerdictCopy">The booked flights, Stockholm stay, and September 7–13 Baltzar stay protect the conference and preserve the nonstop flight home.</span>
+              <strong id="scenarioVerdictTitle">Best new balance</strong>
+              <span id="scenarioVerdictCopy">It fulfills the LEGOLAND promise, gives Aarhus a real day, avoids three consecutive one-night hotels, and removes the rental car from flight morning.</span>
             </div>
           </div>
           <div class="route-line" id="scenarioRoute" aria-label="Selected scenario route">
@@ -3072,13 +3072,13 @@
         </div>
         <div class="route-stop">
           <div class="route-dot">03</div>
-          <strong>Billund</strong>
-          <span>Sep 13–15 · 2 nights</span>
+          <strong>LEGOLAND → Aarhus</strong>
+          <span>Sep 13–15 · 2 Aarhus nights</span>
         </div>
         <div class="route-stop">
           <div class="route-dot">04</div>
-          <strong>Copenhagen → SFO</strong>
-          <span>Sep 15–16 · SK935 nonstop</span>
+          <strong>CPH Airport → SFO</strong>
+          <span>Sep 15–16 · return car + SK935</span>
         </div></div>
           <div class="scenario-days" id="scenarioDays">
         <article class="scenario-day">
@@ -3103,18 +3103,18 @@
         </article>
         <article class="scenario-day">
           <div class="scenario-day-date">Sun · Sep 13</div>
-          <strong>Malmö → LEGOLAND</strong>
-          <p>Transfer early and use a partial park day; official hours are 10:00–18:00.</p>
+          <strong>CPH rental → LEGOLAND → Aarhus</strong>
+          <p>Train directly to Copenhagen Airport, collect the car, use the Sunday park hours, then drive about 70 minutes to Aarhus.</p>
         </article>
         <article class="scenario-day">
           <div class="scenario-day-date">Mon · Sep 14</div>
-          <strong>LEGO House</strong>
-          <p>Book a full 10:00–16:00 visit.</p>
+          <strong>Aarhus family day</strong>
+          <p>Make Den Gamle By the anchor, then use Dokk1 and its harbor playground as the flexible release valve.</p>
         </article>
         <article class="scenario-day">
           <div class="scenario-day-date">Tue–Wed · Sep 15–16</div>
-          <strong>Copenhagen + SK935</strong>
-          <p>Move east Tuesday, sleep in Copenhagen, and fly nonstop Wednesday.</p>
+          <strong>Funen stop + CPH Airport</strong>
+          <p>Choose H.C. Andersen’s House or Egeskov, return the car Tuesday evening, sleep at the airport, and fly nonstop Wednesday.</p>
         </article></div>
         </div>
 
@@ -3138,9 +3138,9 @@
             <div class="calendar-day"><strong>10</strong><span class="day-label conf">Main conference</span></div>
             <div class="calendar-day"><strong>11</strong><span class="day-label conf">Main conference</span></div>
             <div class="calendar-day"><strong>12</strong><span class="day-label conf">Main conference</span></div>
-            <div class="calendar-day"><strong>13</strong><span class="day-label travel">Malmö → Billund</span><span class="day-label lego">LEGOLAND · partial</span></div>
-            <div class="calendar-day"><strong>14</strong><span class="day-label lego">LEGO House · 10–16</span></div>
-            <div class="calendar-day"><strong>15</strong><span class="day-label travel">Billund → Copenhagen</span></div>
+            <div class="calendar-day"><strong>13</strong><span class="day-label lego">LEGOLAND</span><span class="day-label travel">Drive to Aarhus</span></div>
+            <div class="calendar-day"><strong>14</strong><span class="day-label home">Aarhus family day</span></div>
+            <div class="calendar-day"><strong>15</strong><span class="day-label travel">Funen → CPH Airport</span></div>
             <div class="calendar-day"><strong>16</strong><span class="day-label travel">SK935 nonstop home</span></div>
             <div class="calendar-day"><strong>17</strong></div>
             <div class="calendar-day"><strong>18</strong></div>
@@ -3167,24 +3167,24 @@
             <p class="eyebrow">The Nordic corridor</p>
             <h2>Fly north first, then work south and west.</h2>
           </div>
-          <p>The route avoids a connection on the way home: CPH to Stockholm by air, Stockholm to Malmö by rail, then Malmö to Billund and Copenhagen overland.</p>
+          <p>The route avoids a connection on the way home: CPH to Stockholm by air, Stockholm to Malmö by rail, then an airport rental loop through LEGOLAND, Aarhus, Funen, and back to CPH.</p>
         </div>
 
         <div class="map-shell">
           <div class="map-stage">
             <svg id="nordicMap" role="img" aria-labelledby="mapTitle mapDescription" viewBox="0 0 894 620">
               <title id="mapTitle">Southern Nordic map of the ECCV family trip</title>
-              <desc id="mapDescription">A map highlighting Billund, Copenhagen Airport, Malmö and Hyllie, Lund, and the train route to Stockholm.</desc>
+              <desc id="mapDescription">A map highlighting Copenhagen Airport, Billund, Aarhus, Malmö and Hyllie, Lund, and the route to Stockholm.</desc>
             <g><g><path class="map-country" d="M1216.915,-906.105L1141.341,-855.603L1105.551,-843.931L1124.245,-932.715L1067.365,-984.234L998.501,-940.079L976.612,-847.384L934.272,-792.865L886.658,-822.662L828.82,-816.463L779.449,-882.158L752.766,-849.112L725.285,-844.147L718.734,-763.6L635.171,-782.935L623.348,-716.057L580.688,-716.469L551.449,-633.541L507.031,-508.772L438.168,-358.255L454.305,-322.838L438.807,-282.396L394.869,-284.158L366.109,-190.56L368.825,-63.006L397.106,-15.772L382.406,90.873L345.498,151.348L326.005,201.236L296.127,148.012L208.57,247.367L149.293,267.109L87.94,224.095L72.122,131.124L58.062,-79.033L98.964,-140.53L156.679,-181.883L216.08,-222.625L303.797,-327.129L384.963,-474.427L436.225,-581.824L491.693,-692.49L565.989,-782.513L625.188,-860.404L687.897,-939.185L785.361,-996.07L858.378,-989.008L925.963,-1099.782L1006.81,-1093.862L1086.538,-1121.204L1157.237,-1072.143L1225.383,-1022.202L1168.183,-986.961ZM508.629,-2662.832L525.406,-2748.949L590.594,-2757.855L646.516,-2669.72L722.136,-2579.898L792.71,-2491.096L735.902,-2446.43L681.027,-2401.338L656.262,-2241.571L617.436,-2202.398L596.346,-2035.761L542.821,-2028.342L447.275,-2149.303L487.539,-2222.636L421.072,-2283.571L379.413,-2375.981L334.633,-2471.057L300.122,-2657.677L359.544,-2702.963L421.072,-2747.616L445.358,-2659.394ZM1052.985,-2759.193L987.157,-2624.424L922.411,-2610.863L858.378,-2595.778L793.463,-2616.793L727.522,-2636.312L719.533,-2704.876L655.942,-2709.25L607.37,-2827.477L674.919,-2865.543L744.458,-2902.331L808.848,-2838.038L853.745,-2918.42L910.56,-2885.076L965.907,-2850.954ZM933.792,-2247.425L834.731,-2162.387L756.441,-2210.33L786.958,-2264.698L760.276,-2333.444L852.147,-2377.354L869.722,-2295.484Z"></path><path class="map-country is-focus" d="M326.005,201.236L345.498,151.348L382.406,90.873L397.106,-15.772L368.825,-63.006L366.109,-190.56L394.869,-284.158L438.807,-282.396L454.305,-322.838L438.168,-358.255L507.031,-508.772L551.449,-633.541L580.688,-716.469L623.348,-716.057L635.171,-782.935L718.734,-763.6L725.285,-844.147L752.766,-849.112L812.043,-788.846L881.226,-707.221L882.504,-531.2L897.363,-488.228L820.991,-457.505L778.011,-383.333L784.881,-319.624L714.42,-238.187L628.621,-153.629L596.346,-20.268L627.982,44.253L670.322,94.12L629.579,192.73L583.404,212.836L566.468,353.031L541.383,428.442L487.539,420.831L462.294,483.363L411.006,487.026L396.786,412.23L359.718,320.13Z"></path><path class="map-country" d="M709.148,559.261L763.791,567.859L845.436,566.67L868.124,574.853L878.829,598.098L880.747,631.288L893.049,659.517L892.73,688.896L866.207,703.738L879.788,737.353L880.747,769.382L902.956,831.049L898.322,850.704L876.273,858.799L836.01,916.103L847.354,946.683L837.767,942.685L795.586,916.578L763.631,926.17L742.701,919.186L716.338,933.73L693.969,909.573L675.755,918.83L673.198,914.798L652.907,880.929L619.833,876.731L615.679,855.056L585.162,847.315L578.611,865.189L554.485,850.825L557.201,831.657L524.127,825.568L503.037,802.817L484.823,757.455L488.338,732.59L477.313,693.724L461.176,667.591L473.478,647.817L463.253,609.852L493.45,587.745L562.793,552.63L618.715,526.635L662.972,539.593L666.328,558.201Z"></path><path class="map-country" d="M845.436,566.67L841.761,547.182L846.555,526.233L826.902,513.891L780.408,500.421L770.981,434.24L821.79,409.867L896.245,415.007L939.864,407.085L946.095,423.739L969.742,428.856L1012.402,467.167L1016.556,502.175L980.127,526.902L969.902,570.105L921.649,598.622L878.829,598.098L868.124,574.853Z"></path><path class="map-country" d="M1047.553,317.408L1068.963,336.412L1072.797,375.893L1087.017,423.324L1039.404,453.901L1012.402,467.167L969.742,428.856L946.095,423.739L939.864,407.085L896.245,415.007L821.79,409.867L770.981,434.24L772.579,373.924L794.308,322.564L836.169,294.387L871.48,355.863L907.11,354.306L915.578,291.063L953.445,276.278L972.778,286.432L1010.964,317.265Z"></path><path class="map-country" d="M1078.389,147.557L1078.389,147.557L1085.1,162.691L1053.464,212.391L1066.726,291.063L1047.553,317.408L1010.964,317.265L972.778,286.432L953.445,276.278L915.578,291.063L920.691,241.493L904.394,252.059L876.273,222.024L872.438,172.638L928.52,148.315L984.441,135.698L1032.534,150.135L1078.389,147.557Z"></path><path class="map-country" d="M167.987,1040.574L173.579,993.373L195.948,947.271L132.038,934.791L111.107,916.933L113.664,886.917L104.716,871.325L109.829,824.227L102.319,749.729L129.002,749.729L140.186,722.54L151.211,655.536L143.062,630.381L151.69,614.542L188.758,610.504L197.066,627.012L227.104,589.976L217.038,561.512L214.961,518.055L248.514,528.241L276.954,516.444L277.593,546.118L322.49,564.026L322.011,590.894L367.228,576.698L392.153,555.814L442.162,585.906L463.253,609.852L473.478,647.817L461.176,667.591L477.313,693.724L488.338,732.59L484.823,757.455L503.037,802.817L483.225,810.173L471.561,802.08L460.377,815.558L428.422,829.101L411.965,846.589L379.69,861.694L387.519,882.247L392.312,911.237L414.841,927.707L439.926,956.776L424.268,987.804L408.29,996.27L414.681,1039.43L410.527,1050.621L396.626,1037.142L375.376,1035.081L343.581,1046.971L304.436,1044.117L298.204,1061.434L275.676,1043.203L262.415,1046.857L214.802,1026.711L205.694,1041.031Z"></path><path class="map-country is-focus" d="M276.954,516.444L248.514,528.241L214.961,518.055L196.907,474.799L195.628,393.557L202.978,371.813L215.76,347.36L254.745,342.246L270.403,319.557L306.033,296.264L304.595,338.69L291.494,365.33L296.766,387.96L320.893,400.119L310.028,430.238L296.766,421.663L264.811,478.609ZM385.602,427.889L399.662,467.576L373.139,530.514L326.645,486.755L320.413,454.176Z"></path><path class="map-country" d="M1105.551,-843.931L1099,-758.369L1166.905,-679.461L1126.003,-592.503L1177.61,-466.517L1147.732,-375.131L1187.676,-298.114L1169.621,-232.471L1235.289,-165.097L1218.513,-115.84L1177.291,-61.05L1082.384,56.33L1082.384,56.33L1082.384,56.33L1001.857,63.521L923.726,96.282L851.508,114.906L825.784,66.33L782.804,36.699L792.71,-54.05L771.141,-139.86L792.391,-196.534L832.654,-259.07L934.112,-370.221L963.67,-392.292L959.197,-437.148L897.363,-488.228L882.504,-531.2L881.226,-707.221L812.043,-788.846L752.766,-849.112L779.449,-882.158L828.82,-816.463L886.658,-822.662L934.272,-792.865L976.612,-847.384L998.501,-940.079L1067.365,-984.234L1124.245,-932.715Z"></path></g><path class="map-route-core" d="M412.447,471.247L326.956,463.562L241.103,458.246L319.66,461.59L397.997,466.927"></path><path class="map-route-stockholm" d="M638.448,160.28L577.47,239.415L519.624,317.657L464.686,394.948L412.447,471.247"></path><path class="map-route-flight" d="M397.997,466.927L451.699,385.028L508.393,301.893L568.332,217.557L631.79,132.078"></path><g><g class="map-location" transform="translate(241.1027910098316,458.2464342147464)"><line class="map-leader" x2="-18" y2="-24"></line><circle class="map-marker-halo" r="9"></circle><circle class="map-marker-core" r="4.5"></circle><text class="map-label" x="-23" y="-24" text-anchor="end"><tspan x="-23">Billund</tspan><tspan class="map-label-note" x="-23" dy="14">2 nights · LEGO finish</tspan></text></g><g class="map-location" transform="translate(397.9965474945027,466.9274139160475)"><line class="map-leader" x2="-62" y2="33"></line><circle class="map-marker-halo" r="9"></circle><circle class="map-marker-core" r="4.5"></circle><text class="map-label" x="-67" y="33" text-anchor="end"><tspan x="-67">Copenhagen / CPH</tspan><tspan class="map-label-note" x="-67" dy="14">final night + SK935</tspan></text></g><g class="map-location" transform="translate(412.447229826377,471.24697490668586)"><line class="map-leader" x2="54" y2="28"></line><circle class="map-marker-halo" r="9"></circle><circle class="map-marker-core" r="4.5"></circle><text class="map-label" x="59" y="28" text-anchor="start"><tspan x="59">Malmö / Hyllie</tspan><tspan class="map-label-note" x="59" dy="14">Radisson + ECCV</tspan></text></g><g class="map-location" transform="translate(421.79401637150204,460.1137693956457)"><line class="map-leader" x2="50" y2="-30"></line><circle class="map-marker-halo" r="9"></circle><circle class="map-marker-core" r="4.5"></circle><text class="map-label" x="55" y="-30" text-anchor="start"><tspan x="55">Lund</tspan><tspan class="map-label-note" x="55" dy="14">easy family day</tspan></text></g><g class="map-location is-stockholm" transform="translate(638.4477352636325,160.28024557227445)"><line class="map-leader" x2="18" y2="-24"></line><circle class="map-marker-halo" r="9"></circle><circle class="map-marker-core" r="4.5"></circle><text class="map-label" x="23" y="-24" text-anchor="start"><tspan x="23">Stockholm</tspan><tspan class="map-label-note" x="23" dy="14">first 3 nights</tspan></text></g></g></g></svg>
           </div>
           <aside class="map-panel" aria-label="Map legend and route notes">
             <div>
               <h3>Three travel zones</h3>
-              <p>Stockholm is the arrival chapter, Malmö–Lund is the conference corridor, and Billund is the family finish before a protected Copenhagen departure night.</p>
+              <p>Stockholm is the arrival chapter, Malmö–Lund is the conference corridor, and the airport–Billund–Aarhus loop is the family road-trip finish.</p>
               <div class="map-legend">
                 <div class="map-key"><span class="map-key-line flight"></span><span>Air · CPH to Stockholm</span></div>
                 <div class="map-key"><span class="map-key-line stockholm"></span><span>Rail · Stockholm to Malmö</span></div>
-                <div class="map-key"><span class="map-key-line"></span><span>Ground · Malmö to Billund to CPH</span></div>
+                <div class="map-key"><span class="map-key-line"></span><span>Road · CPH to Billund to Aarhus to CPH</span></div>
                 <div class="map-key"><span class="map-key-dot"></span><span>Trip location</span></div>
               </div>
             </div>
@@ -3460,16 +3460,16 @@
                   </tr>
                   <tr>
                     <td>Hotels</td>
-                    <td>Billund and Copenhagen</td>
-                    <td>3 remaining room nights planned</td>
+                    <td>Aarhus and Copenhagen Airport</td>
+                    <td>3 remaining room nights planned · recommended 2 + 1 split</td>
                     <td class="num">—</td>
                     <td class="num">—</td>
                     <td class="pending">Not yet booked</td>
                   </tr>
                   <tr>
                     <td>Rail + ground</td>
-                    <td>Stockholm → Malmö → Billund → Copenhagen</td>
-                    <td>Family of four</td>
+                    <td>Stockholm → Malmö · CPH Airport rental loop</td>
+                    <td>Family of four · LEGOLAND, Aarhus, Funen</td>
                     <td class="num">—</td>
                     <td class="num">—</td>
                     <td class="pending">Not yet booked</td>
@@ -3970,31 +3970,72 @@
       <div class="wrap">
         <div class="section-head">
           <div>
-            <p class="eyebrow">Billund + Copenhagen finish</p>
-            <h2>Two Billund nights, then one protected Copenhagen night.</h2>
+            <p class="eyebrow">Three-night Denmark road trip</p>
+            <h2>LEGOLAND is fixed. Where the family sleeps is not.</h2>
           </div>
-          <p>The preferred sequence is Malmö → Billund early September 13, a partial LEGOLAND day, LEGO House on September 14, and Copenhagen on September 15. It keeps the family in Malmö through the full conference.</p>
+          <p>A car changes the design space. The best current plan is to collect it at Copenhagen Airport, visit LEGOLAND Sunday, continue to Aarhus for two nights, and return the car Tuesday evening before sleeping beside the airport.</p>
         </div>
 
         <div class="image-feature">
           <div class="image-feature-photo" role="img" aria-label="Exterior of LEGO House in Billund"></div>
           <div class="image-feature-copy">
-            <span class="tag yellow">Date-specific sequence</span>
-            <h3>Park on arrival. House Monday. Copenhagen Tuesday.</h3>
-            <p>LEGOLAND is open Sunday, September 13, from 10:00–18:00, making a noon-ish arrival usable. LEGO House is open Monday, September 14, from 10:00–16:00. Both anchors are closed Tuesday, September 15.</p>
+            <span class="tag yellow">The immovable window</span>
+            <h3>LEGOLAND must happen Sunday.</h3>
+            <p>LEGOLAND is open September 13 from 10:00–18:00, with rides closing one hour before the park. Leave Baltzar around 06:45, take the direct train to Copenhagen Airport, collect the car around 08:00, and aim to reach the park near 11:00.</p>
             <div class="opening-pair">
-              <div class="opening-card critical"><strong>Sun · Sep 13</strong><span>LEGOLAND · 10:00–18:00 · partial day</span></div>
-              <div class="opening-card"><strong>Mon · Sep 14</strong><span>LEGO House · 10:00–16:00</span></div>
+              <div class="opening-card critical"><strong>Sun · Sep 13</strong><span>LEGOLAND · 10:00–18:00 · rides close 17:00</span></div>
+              <div class="opening-card"><strong>After the park</strong><span>Billund → Aarhus · about 70 minutes</span></div>
             </div>
           </div>
         </div>
 
-        <div class="mini-steps" aria-label="Recommended Billund sequence">
+        <div class="mini-steps" aria-label="Recommended Denmark road-trip sequence">
           <article class="mini-step"><strong>Saturday, Sep 12</strong><span>Finish ECCV without watching the clock. Eat and sleep in Malmö, with bags packed for a prompt Sunday departure.</span></article>
-          <article class="mini-step"><strong>Sunday, Sep 13</strong><span>Leave Malmö early, check bags at the Billund hotel, and use the remaining LEGOLAND hours. Six hours is likely enough for two early-elementary-age children.</span></article>
-          <article class="mini-step"><strong>Monday, Sep 14</strong><span>Book LEGO House at 10:00. Its indoor six-hour day is a better fit than trying to squeeze it around Sunday’s transfer.</span></article>
-          <article class="mini-step"><strong>Tuesday, Sep 15</strong><span>Check out and move east. Add Jelling or a Copenhagen afternoon, then sleep near central Copenhagen or the airport.</span></article>
+          <article class="mini-step"><strong>Sunday, Sep 13</strong><span>Train Malmö C → CPH Airport, pick up the reserved family car and child seats, drive about 2h50 to LEGOLAND, then continue to Aarhus after closing.</span></article>
+          <article class="mini-step"><strong>Monday, Sep 14</strong><span>Give Aarhus a real day: Den Gamle By as the anchor, then Dokk1, the harbor playground, or an early dinner depending on energy.</span></article>
+          <article class="mini-step"><strong>Tuesday, Sep 15</strong><span>Cross Funen with one optional stop, return the car at CPH that evening, and sleep by Terminal 3 before SK935.</span></article>
         </div>
+
+        <div class="flight-strategy">
+          <article class="strategy-card recommended"><span class="tag">Recommended</span><h3>LEGOLAND + 2 Aarhus nights + CPH</h3><p>Drive directly from the park to Aarhus Sunday evening. Monday becomes a full city day; Tuesday can include Odense or Egeskov. The cost is giving up LEGO House.</p></article>
+          <article class="strategy-card"><span class="tag blue">Maximum LEGO</span><h3>Billund + Aarhus + CPH</h3><p>Sleep in Billund Sunday, visit LEGO House Monday, then sleep in Aarhus. It includes both LEGO anchors but creates three consecutive one-night stays and compresses Aarhus.</p></article>
+          <article class="strategy-card"><span class="tag yellow">Calmest</span><h3>2 Billund nights + CPH</h3><p>Keep the previous Hotel LEGOLAND plan and use Tuesday for Egeskov or Odense. It minimizes Sunday fatigue but drops Aarhus from the trip.</p></article>
+        </div>
+
+        <div class="program-watch"><div><p class="eyebrow">Why Aarhus earns two nights</p><h3>One major museum, one free play valve, and no pressure to “complete” the city.</h3><p>Aarhus—roughly “OR-hoos”—is Denmark’s second city. For this family, its appeal is the mix of tactile history, good design, harbor life, and easy spaces where the children can move.</p></div><div class="watch-grid">
+          <div class="watch-topic"><strong>Den Gamle By · first choice</strong><span>The open-air Old Town is open 10:00–17:00 and recommends 4–5 hours. Children 0–17 enter free. It is the best single Aarhus anchor for both adults and young children.</span></div>
+          <div class="watch-topic"><strong>Dokk1 + Kloden · perfect release valve</strong><span>The harbor library has indoor family spaces and a free outdoor playground themed around five world regions. Use it after the museum or whenever attention runs out.</span></div>
+          <div class="watch-topic"><strong>Moesgaard · rainy-day swap</strong><span>Interactive archaeology, Vikings, Grauballe Man, and a junior lab make this the strongest indoor alternative. Children under 18 are free, and the grassy museum roof supplies needed movement.</span></div>
+          <div class="watch-topic"><strong>ARoS · short iconic add-on</strong><span>The rainbow panorama is visually memorable and children under 18 are free. September 14 is an exception day closing at 16:00, so use it first thing or save it for Tuesday morning.</span></div>
+          <div class="watch-topic"><strong>Marselisborg Deer Park · outdoor reset</strong><span>A free forest walk among deer and wild boar, best when everyone needs nature more than another ticket. The car makes it easy to combine with Moesgaard.</span></div>
+          <div class="watch-topic"><strong>Monday rhythm</strong><span>Choose Den Gamle By or Moesgaard—not both. Add Dokk1, the Latin Quarter, or an early dinner only if the children still have fuel.</span></div>
+        </div></div>
+
+        <div class="program-watch"><div><p class="eyebrow">Aarhus hotel shortlist · Sep 13–15</p><h3>Prioritize two real beds for the children and uncomplicated parking.</h3><p>These rankings use official room capacities and parking information, not live September inventory or rates.</p></div><div class="watch-grid">
+          <div class="watch-topic"><strong>1 · Comwell Aarhus · best room setup</strong><span>Standard and Superior Quadruple rooms have two double beds in 28 m², a major improvement over a shared sofa bed. Paid on-site parking and a walkable design-hotel location fit the road trip well.</span></div>
+          <div class="watch-topic"><strong>2 · Scandic Aarhus City · best central base</strong><span>The official Family Four sleeps four in 25 m², with ARoS 400 m away and paid Q-Park below. The hotel cannot guarantee parking, and the room may use a sofa bed for the children.</span></div>
+          <div class="watch-topic"><strong>3 · Scandic The Mayor · best space splurge</strong><span>The 40 m² Master Suite adds a separate bedroom, living room, kitchenette, terrace, and space for four. Choose it only if the premium is reasonable and parking logistics are confirmed.</span></div>
+          <div class="watch-topic"><strong>Car-first fallback · Scandic Aarhus Vest</strong><span>Free fenced parking and Family Four rooms remove city-garage anxiety, but the hotel is 4 km outside the center and gives up the walkable Aarhus evening.</span></div>
+        </div></div>
+
+        <div class="program-watch"><div><p class="eyebrow">Tuesday across Funen</p><h3>Choose one road-trip stop—or skip both and reach Copenhagen early.</h3><p>Do not turn September 15 into another checklist. Both options work only because the car is already moving east toward Copenhagen Airport.</p></div><div class="watch-grid">
+          <div class="watch-topic"><strong>Rain or imagination · Odense</strong><span>H.C. Andersen’s House is open 10:00–17:00 and recommends 1.5–2 hours. The play-and-costume children’s world, Ville Vau, opens at 13:00 on Tuesday; reserve timed entry and target roughly 13:00–15:30.</span></div>
+          <div class="watch-topic"><strong>Dry weather · Egeskov</strong><span>The castle, gardens, vintage collections, maze, TreeTop Walking, and large Play Forest are a bigger all-family draw. The 2026 summer season covers September 15; allow 3–4 hours and skip ARoS that morning.</span></div>
+          <div class="watch-topic"><strong>Low-energy option · direct to CPH</strong><span>Have a slow Aarhus breakfast, drive straight east, return the car, and use the metro for a familiar Copenhagen dinner. This is the correct choice if the children are saturated.</span></div>
+        </div></div>
+
+        <div class="program-watch"><div><p class="eyebrow">Car + final-night operating plan</p><h3>Airport round trip, Sunday morning to Tuesday evening.</h3><p>The Malmö train stops at Copenhagen Airport before Copenhagen Central. The airport rental center is reached by a free terminal bus and major desks operate much longer on Sunday than the central-city branch.</p></div><div class="watch-grid">
+          <div class="watch-topic"><strong>Pickup</strong><span>Reserve CPH Airport around 08:00 on September 13. Book an automatic family-size wagon/crossover with luggage hidden below the cargo cover, full damage terms, unlimited mileage, and two appropriate child restraints.</span></div>
+          <div class="watch-topic"><strong>Road costs</strong><span>The western loop crosses the Great Belt twice. Budget two tolls plus fuel, Aarhus parking, and the rental; verify whether the company passes tolls through automatically or adds an administration fee.</span></div>
+          <div class="watch-topic"><strong>Return</strong><span>Return the car at CPH Airport on September 15 before hotel check-in. Photograph the vehicle, fuel/charge level, mileage, and return bay. Do not carry rental-return risk into the SK935 morning.</span></div>
+          <div class="watch-topic"><strong>Child seats</strong><span>Danish rules require an appropriate restraint until a child is at least 135 cm tall. Reserve by child height and weight, or bring familiar travel seats rather than accepting an unspecified “booster.”</span></div>
+          <div class="watch-topic"><strong>Final-night splurge · Clarion CPH</strong><span>Two minutes from Terminal 3; the 45 m² Family Room has a double bed and sofa bed. Best when maximum morning ease and a full-service finish justify the rate.</span></div>
+          <div class="watch-topic"><strong>Final-night value · Comfort CPH</strong><span>The official Family Room uses two 140 cm double beds, a better sleep layout for four. It is the practical first price comparison against Clarion.</span></div>
+        </div></div>
+
+        <p class="decision-note"><strong>Current recommendation:</strong> reserve a cancellable two-night Aarhus room and one airport night, then price a same-location CPH Airport rental for September 13–15. Keep one cancellable Billund room only while deciding whether LEGO House is important enough to replace a full Aarhus day.</p>
+
+        <details class="decision-archive"><summary>Earlier Billund-base and train-first research</summary><div class="archive-body">
 
         <div class="program-watch">
           <div>
@@ -4078,7 +4119,7 @@
           </article>
         </div>
 
-        <p class="decision-note"><strong>Best September 15 variation:</strong> Jelling is the most distinctive cultural stop if transport and luggage are simple; Copenhagen is the safest default. Lalandia is excellent in rain but awkward on checkout day with wet gear. Save Givskud for a true extra day with a car.</p>
+        <p class="decision-note"><strong>Earlier conclusion:</strong> the two-night Billund plan remains the calmest fallback, but it no longer leads now that a broader Denmark road trip and Aarhus are in scope.</p></div></details>
       </div>
     </section><section id="book" class="section-white">
       <div class="wrap">
@@ -4102,13 +4143,13 @@
             <label class="check-item"><input type="checkbox" data-check="flights" checked disabled><span class="check-copy"><strong>SAS flights booked</strong><span>SK936 + SK1426 outbound and SK935 nonstop home are confirmed for four travelers. Approximate paid total: $6.1k.</span></span><span class="priority later">Booked</span></label>
             <label class="check-item"><input type="checkbox" data-check="malmo-hotel" checked disabled><span class="check-copy"><strong>Home Hotel Baltzar booked · Sep 7–13</strong><span>Junior Suite for four · approximately $2.8k · free cancellation until Sep 5 at 11:59pm local. Reservation number redacted.</span></span><span class="priority later">Booked</span></label>
             <label class="check-item"><input type="checkbox" data-check="stockholm-hotel" checked disabled><span class="check-copy"><strong>Scandic Continental Master Suite booked · Sep 4–7</strong><span>Family of four · about $1.5k · non-refundable; reservation and payment details redacted.</span></span><span class="priority later">Booked</span></label>
-            <label class="check-item"><input type="checkbox" data-check="billund-hotel"><span class="check-copy"><strong>Hold Hotel LEGOLAND · Sep 13–15</strong><span>Search a four-bed themed room first; compare The Lodge and Refborg only if the rate or bed setup is materially better. Confirm early luggage storage.</span></span><span class="priority">Now</span></label>
-            <label class="check-item"><input type="checkbox" data-check="cph-hotel"><span class="check-copy"><strong>Hold Scandic Spectrum · Sep 15</strong><span>Price a Family Four and Junior Suite; use Tivoli Hotel as the pool-forward backup. The 12:45 flight does not require a Kastrup stay.</span></span><span class="priority">Now</span></label>
-            <label class="check-item"><input type="checkbox" data-check="transfer"><span class="check-copy"><strong>Book the three scarce train legs</strong><span>Direct SJ Stockholm → Malmö plus DSB Copenhagen → Vejle and Vejle → Copenhagen. Prefer Orange Fri and reserve four adjacent seats; no rental car by default.</span></span><span class="priority">Now</span></label>
-            <label class="check-item"><input type="checkbox" data-check="lego"><span class="check-copy"><strong>Book LEGOLAND + LEGO House entries</strong><span>Use a partial LEGOLAND day September 13 and LEGO House September 14. Both anchors are closed September 15.</span></span><span class="priority soon">Soon</span></label>
+            <label class="check-item"><input type="checkbox" data-check="billund-hotel"><span class="check-copy"><strong>Hold Aarhus · Sep 13–15</strong><span>Price Comwell Quadruple first, then Scandic Aarhus City Family Four and The Mayor Master Suite. Keep the rate cancellable while the LEGO House tradeoff is open.</span></span><span class="priority">Now</span></label>
+            <label class="check-item"><input type="checkbox" data-check="cph-hotel"><span class="check-copy"><strong>Hold CPH Airport · Sep 15</strong><span>Compare Clarion’s 45 m² Family Room with Comfort’s two-double-bed Family Room. Both remove airport logistics from the flight morning.</span></span><span class="priority">Now</span></label>
+            <label class="check-item"><input type="checkbox" data-check="transfer"><span class="check-copy"><strong>Reserve CPH Airport car · Sep 13–15</strong><span>Same-location airport rental, automatic family car with covered luggage space, unlimited mileage, clear damage terms, and two height/weight-appropriate child seats.</span></span><span class="priority">Now</span></label>
+            <label class="check-item"><input type="checkbox" data-check="lego"><span class="check-copy"><strong>Book LEGOLAND · Sep 13</strong><span>This Sunday is the only park window in the final three nights. Decide separately whether LEGO House is worth replacing a full Aarhus day.</span></span><span class="priority">Now</span></label>
             <label class="check-item"><input type="checkbox" data-check="eccv"><span class="check-copy"><strong>Register and lock the Sep 8–9 workshop plan</strong><span>Primary plan: Multimodal Digital Agents on Tuesday and World Models for Embodied AI on Wednesday.</span></span><span class="priority">Now</span></label>
             <label class="check-item"><input type="checkbox" data-check="poster"><span class="check-copy"><strong>Capture the poster's exact assignment</strong><span>Date, session, time, room, and board are still TBA; watch the author inbox and official program. Paper identity is redacted publicly.</span></span><span class="priority soon">Soon</span></label>
-            <label class="check-item"><input type="checkbox" data-check="rail"><span class="check-copy"><strong>Install local rail + bus apps</strong><span>Use Skånetrafiken for Malmö/Öresund, DSB for Denmark, and Rejseplanen for the Vejle–Billund bus. Carry valid ID.</span></span><span class="priority later">Later</span></label>
+            <label class="check-item"><input type="checkbox" data-check="rail"><span class="check-copy"><strong>Book SJ; keep local trains flexible</strong><span>Reserve Stockholm → Malmö now. Use Skånetrafiken for the September 13 direct Malmö → CPH Airport train and carry valid ID.</span></span><span class="priority soon">Soon</span></label>
             <label class="check-item"><input type="checkbox" data-check="dinner"><span class="check-copy"><strong>Pick one Stockholm classic dinner</strong><span>Tradition in Gamla Stan is a straightforward first-timer option; keep the other meals flexible.</span></span><span class="priority later">Later</span></label>
           </div>
         </div>
@@ -4161,6 +4202,10 @@
               <li><a href="https://www.dsb.dk/togture-i-danmark/kobenhavn-vejle/" target="_blank" rel="noreferrer">DSB: Copenhagen–Vejle InterCityLyn</a></li>
               <li><a href="https://www.dsb.dk/en/find-produkter-og-services/orange-fri/" target="_blank" rel="noreferrer">DSB Orange Fri flexibility, child, and sale-window rules</a></li>
               <li><a href="https://www.storebaelt.dk/en/prices-and-discounts/private/" target="_blank" rel="noreferrer">Great Belt 2026 car tolls</a></li>
+              <li><a href="https://www.cph.dk/en/parking-transport/other-parking-options/car%20rental" target="_blank" rel="noreferrer">Copenhagen Airport Car Rental Centre + terminal bus</a></li>
+              <li><a href="https://www.sixt.dk/billeje/danmark/kobenhavn/kobenhavns-lufthavn/" target="_blank" rel="noreferrer">CPH Airport rental hours · 07:00–23:00 daily</a></li>
+              <li><a href="https://www.sixt.com/car-rental/denmark/copenhagen/copenhagen-city-centre/" target="_blank" rel="noreferrer">Copenhagen city rental hours · Sunday comparison</a></li>
+              <li><a href="https://www.sikkertrafik.dk/rad-og-viden/bil/born-i-bilen/born-i-bilen-hvad-siger-loven/" target="_blank" rel="noreferrer">Danish child-restraint rule · 135 cm</a></li>
             </ul>
           </div>
           <div class="source-group">
@@ -4172,6 +4217,20 @@
               <li><a href="https://wowpark.dk/en" target="_blank" rel="noreferrer">WOW PARK Billund</a></li>
               <li><a href="https://www.givskudzoo.dk/da/besoeg-zoo/aabningstider/" target="_blank" rel="noreferrer">Givskud Zoo 2026 season</a></li>
               <li><a href="https://kongernesjelling.dk/en/visit-us" target="_blank" rel="noreferrer">Kongernes Jelling visitor information</a></li>
+            </ul>
+          </div>
+          <div class="source-group">
+            <h3>Aarhus + Funen</h3>
+            <ul>
+              <li><a href="https://www.dengamleby.dk/en/plan-your-visit/tickets-and-opening-hours/" target="_blank" rel="noreferrer">Den Gamle By hours, visit length, and free child admission</a></li>
+              <li><a href="https://www.visitaarhus.com/aarhus/see-and-do/family/aarhus-children" target="_blank" rel="noreferrer">VisitAarhus family guide</a></li>
+              <li><a href="https://www.visitaarhus.com/aarhus-region/plan-your-trip/childrens-playground-kloden-gdk1010811" target="_blank" rel="noreferrer">Dokk1 Kloden playground</a></li>
+              <li><a href="https://moesgaardmuseum.dk/en/exhibitions/especially-for-children" target="_blank" rel="noreferrer">Moesgaard Junior + free child admission</a></li>
+              <li><a href="https://www.aros.dk/en/practical/" target="_blank" rel="noreferrer">ARoS September 14 hours and child admission</a></li>
+              <li><a href="https://hcandersenshus.dk/en/openinghours/" target="_blank" rel="noreferrer">H.C. Andersen’s House + Ville Vau September hours</a></li>
+              <li><a href="https://hcandersenshus.dk/en/plan-your-visit/" target="_blank" rel="noreferrer">H.C. Andersen visit length and timed tickets</a></li>
+              <li><a href="https://egeskov.dk/en/visit-egeskov/opening-hours-and-prices" target="_blank" rel="noreferrer">Egeskov 2026 season and admission</a></li>
+              <li><a href="https://egeskov.dk/en/experiences/play" target="_blank" rel="noreferrer">Egeskov Play Forest + TreeTop Walking</a></li>
             </ul>
           </div>
           <div class="source-group">
@@ -4195,6 +4254,12 @@
               <li><a href="https://www.tivolihotel.com/facilities-and-services/swimming-pool-and-sauna" target="_blank" rel="noreferrer">Tivoli Hotel indoor pool</a></li>
               <li><a href="https://www.scandichotels.com/en/hotels/scandic-copenhagen" target="_blank" rel="noreferrer">Scandic Copenhagen Standard Family Four</a></li>
               <li><a href="https://www.scandichotels.com/en/hotels/scandic-cph-strandpark" target="_blank" rel="noreferrer">Scandic CPH Strandpark family rooms</a></li>
+              <li><a href="https://www.comwell.com/en/hotels/comwell-hotel-aarhus" target="_blank" rel="noreferrer">Comwell Aarhus quadruple rooms</a></li>
+              <li><a href="https://www.comwell.com/en/hotels/comwell-hotel-aarhus/faq" target="_blank" rel="noreferrer">Comwell Aarhus parking</a></li>
+              <li><a href="https://www.scandichotels.com/en/hotels/scandic-aarhus-city" target="_blank" rel="noreferrer">Scandic Aarhus City Family Four + parking</a></li>
+              <li><a href="https://www.scandichotels.com/en/hotels/scandic-the-mayor" target="_blank" rel="noreferrer">Scandic The Mayor Master Suite</a></li>
+              <li><a href="https://www.strawberryhotels.com/hotels/denmark/kastrup/clarion-hotel-copenhagen-airport/" target="_blank" rel="noreferrer">Clarion Copenhagen Airport Family Room</a></li>
+              <li><a href="https://www.strawberryhotels.com/hotels/denmark/kastrup/comfort-hotel-copenhagen-airport/" target="_blank" rel="noreferrer">Comfort Copenhagen Airport Family Room</a></li>
             </ul>
           </div>
           <div class="source-group">
@@ -4227,7 +4292,7 @@
           <div class="source-group">
             <h3>Important caveats</h3>
             <ul>
-              <li>Home Hotel Baltzar and Scandic Continental are confirmed; the Billund and Copenhagen hotel rankings compare official room types and locations, not live September 2026 inventory or rates.</li>
+              <li>Home Hotel Baltzar and Scandic Continental are confirmed; the Aarhus, Billund, and CPH Airport hotel rankings compare official room types and locations, not live September 2026 inventory or rates.</li>
               <li>The Scandic Continental Master Suite rate is non-refundable; contact the property in advance if arrival may be after midnight.</li>
               <li>Drive time and door-to-door commute times are planning estimates.</li>
               <li>The main-conference program and poster session assignment are not yet public.</li>
@@ -4236,7 +4301,7 @@
             </ul>
           </div>
         </div>
-        <p class="as-of">Public planning edition updated August 18, 2026. The SAS itinerary, Scandic Continental stay, and Home Hotel Baltzar stay are confirmed, with approximate combined booked costs of $10.4k. Passenger names, reservation identifiers, assigned seats, account credits, payment details, and the conference paper identity are omitted. Hotel LEGOLAND and Scandic Spectrum are the current unbooked lodging recommendations. The transport default is rail, with a Vejle–Billund bus or taxi rather than a rental car.</p>
+        <p class="as-of">Public planning edition updated August 18, 2026. The SAS itinerary, Scandic Continental stay, and Home Hotel Baltzar stay are confirmed, with approximate combined booked costs of $10.4k. Passenger names, reservation identifiers, assigned seats, account credits, payment details, and the conference paper identity are omitted. The current western recommendation is a CPH Airport rental, LEGOLAND Sunday, two Aarhus nights, a Funen stop, and a protected CPH Airport night.</p>
       </div>
     </section><section id="archive" class="archive-section">
       <div class="wrap">
@@ -4319,6 +4384,7 @@
     // Keep the pre-rendered fallback map current if the live D3 map cannot load.
     document.querySelectorAll("#nordicMap .map-label-note").forEach((note) => {
       if (note.textContent.trim() === "Radisson + ECCV") note.textContent = "Baltzar + ECCV";
+      if (note.textContent.trim() === "2 nights · LEGO finish") note.textContent = "LEGOLAND stop";
     });
 
     const scenarios = {
@@ -4390,10 +4456,43 @@
       }
     };
 
+    Object.assign(scenarios, {
+      aarhusLoop: {
+        dates: "Sep 3–16 · western loop Sep 13–15",
+        title: "LEGOLAND, two Aarhus nights, CPH Airport",
+        summary: "Fulfill the Sunday LEGOLAND promise, give Aarhus a complete family day, and finish with a protected airport night.",
+        verdictTitle: "Recommended",
+        verdictCopy: "This is the best balance of novelty, hotel stability, and flight protection; the deliberate sacrifice is LEGO House.",
+        route: [["Stockholm", "Sep 4–7", "3 nights"], ["Malmö", "Sep 7–13", "Baltzar + ECCV"], ["LEGOLAND → Aarhus", "Sep 13–15", "2 Aarhus nights"], ["CPH Airport → SFO", "Sep 15–16", "return car + SK935"]],
+        days: [["Sep 3–13", "Booked framework", "Confirmed SAS travel, Stockholm, direct rail to Malmö, and six nights at Baltzar through the full ECCV program."], ["Sun · Sep 13", "CPH rental → LEGOLAND → Aarhus", "Leave Malmö early, collect the car at CPH Airport around 08:00, use the park until 18:00, then drive about 70 minutes to Aarhus."], ["Mon · Sep 14", "Aarhus family day", "Choose Den Gamle By or Moesgaard as the anchor; add Dokk1 and its free playground only if energy remains."], ["Tue · Sep 15", "Funen → CPH Airport", "Choose Odense, Egeskov, or a direct drive; return the car Tuesday evening and sleep beside Terminal 3."], ["Wed · Sep 16", "SK935 nonstop", "Walk to the terminal for the confirmed 12:45 departure without a rental-car task remaining."]]
+      },
+      legoHouse: {
+        dates: "Sep 3–16 · western loop Sep 13–15",
+        title: "Billund, LEGO House, Aarhus, CPH Airport",
+        summary: "Use one night in each place to keep both LEGO anchors and still sample Aarhus before the flight.",
+        verdictTitle: "Maximum LEGO, maximum churn",
+        verdictCopy: "It delivers the richest LEGO finish but creates three one-night stays in a row and reduces Aarhus to an evening plus one partial day.",
+        route: [["Stockholm", "Sep 4–7", "3 nights"], ["Malmö", "Sep 7–13", "Baltzar + ECCV"], ["Billund → Aarhus", "Sep 13–15", "1 night each"], ["CPH Airport → SFO", "Sep 15–16", "1 night"]],
+        days: [["Sun · Sep 13", "LEGOLAND + Billund", "Drive from CPH Airport, use the Sunday park window, and sleep at Hotel LEGOLAND or The Lodge."], ["Mon · Sep 14", "LEGO House → Aarhus", "Visit LEGO House 10:00–16:00, then drive about 70 minutes and check into Aarhus."], ["Tue · Sep 15", "Aarhus → CPH Airport", "Choose one Aarhus anchor, leave by mid-afternoon, return the car, and sleep at the airport."], ["Tradeoff", "Every night is a move", "Choose this only if LEGO House matters more than an unhurried Aarhus day and two nights in one room."]]
+      },
+      billundCalm: {
+        dates: "Sep 3–16 · western loop Sep 13–15",
+        title: "Two Billund nights, Funen, CPH Airport",
+        summary: "Keep the original LEGO-centered base, then use the car to add one distinctive stop while crossing Denmark Tuesday.",
+        verdictTitle: "Calmest logistics",
+        verdictCopy: "Sunday ends early and only Tuesday is a moving day, but Aarhus drops out of the trip.",
+        route: [["Stockholm", "Sep 4–7", "3 nights"], ["Malmö", "Sep 7–13", "Baltzar + ECCV"], ["Billund", "Sep 13–15", "2 nights"], ["Funen → CPH Airport", "Sep 15–16", "1 night"]],
+        days: [["Sun · Sep 13", "LEGOLAND + Billund", "Drive from CPH Airport, visit the park, and sleep beside the attraction."], ["Mon · Sep 14", "LEGO House", "Use the full 10:00–16:00 indoor day and keep the same hotel."], ["Tue · Sep 15", "Egeskov or Odense", "Choose one Funen stop on the eastbound drive, return the car, and sleep at CPH Airport."], ["Tradeoff", "No Aarhus", "This is the recovery-friendly answer if the conference week leaves the family short on energy."]]
+      }
+    });
+    delete scenarios.reverse;
+    delete scenarios.posterSafe;
+    delete scenarios.billundLate;
+
     const scenarioButtons = Array.from(document.querySelectorAll("[data-scenario]"));
     const scenarioRoute = document.getElementById("scenarioRoute");
     const scenarioDays = document.getElementById("scenarioDays");
-    let activeScenario = "reverse";
+    let activeScenario = "aarhusLoop";
 
     function renderScenario(key) {
       const scenario = scenarios[key];
@@ -4420,7 +4519,7 @@
     }
 
     scenarioButtons.forEach((button) => button.addEventListener("click", () => renderScenario(button.dataset.scenario)));
-    renderScenario("reverse");
+    renderScenario("aarhusLoop");
 
     const filterButtons = Array.from(document.querySelectorAll("[data-filter]"));
     const hotelCards = Array.from(document.querySelectorAll(".hotel-card[data-area]"));
@@ -4491,8 +4590,8 @@ CORE DATES
 • ECCV workshops/tutorials: September 8–9
 • ECCV main conference: September 10–12
 • Malmö: September 7–13
-• Billund: September 13–15
-• Copenhagen final night: September 15
+• Denmark road trip: September 13–15 · LEGOLAND, Aarhus, and optional Funen stop
+• Copenhagen Airport final night: September 15
 • Fly home nonstop: Wednesday, September 16 on SK935
 • Family: four travelers with two young children
 • School impact: about 8 missed days, pending school-calendar confirmation
@@ -4521,14 +4620,15 @@ CURRENT RECOMMENDATION
 • Live family fares checked August 9 ranged from SEK 2,196 to SEK 2,978 for early direct trains
 • Home Hotel Baltzar Junior Suite is booked September 7–13; confirm the sofa bed is prepared for both children
 • Baltzar → ECCV is about 22–28 minutes door to venue via Malmö C and Hyllie
-• Sleep in Malmö after ECCV on September 12; transfer to Billund early September 13
-• Sunday September 13: partial LEGOLAND day, open 10:00–18:00
-• Monday September 14: LEGO House, 10:00–16:00
-• Transfer Billund → Copenhagen September 15 and sleep there before SK935
-• Billund hotel first choice: a four-bed room at Hotel LEGOLAND; The Lodge is the quieter backup
-• Copenhagen first choice: Scandic Spectrum Family Four or Junior Suite; Tivoli Hotel is the pool-forward backup
-• Transport verdict: train throughout, with bus 43 or taxi between Vejle and Billund; do not rent a car unless adding Lalandia plus a driving day
-• Book now: direct SJ Stockholm → Malmö and DSB Orange Fri Copenhagen ↔ Vejle, with four adjacent reserved seats
+• Sleep in Malmö after ECCV on September 12; take the direct train to Copenhagen Airport early September 13
+• Collect a reserved car at CPH Airport around 08:00; airport desks have much better Sunday hours than central Copenhagen branches
+• Sunday September 13: drive about 2h50 to LEGOLAND, visit during the 10:00–18:00 opening window, then drive about 70 minutes to Aarhus
+• Sleep in Aarhus September 13–15; use Den Gamle By or Moesgaard as Monday's anchor, with Dokk1 as an easy family release valve
+• Tuesday September 15: choose Odense, Egeskov, or a direct drive east; return the car at CPH Airport and sleep beside Terminal 3
+• Aarhus first choice: Comwell Aarhus Quadruple; Scandic Aarhus City is the walkable backup and Scandic The Mayor the space splurge
+• Airport first choice: Clarion Copenhagen Airport Family Room for maximum ease; compare the two-bed Family Room at Comfort Copenhagen Airport
+• Transport verdict: rail through Stockholm and Malmö, then a same-location CPH Airport rental September 13–15; reserve two child restraints and budget two Great Belt tolls
+• Book now: direct SJ Stockholm → Malmö, the CPH Airport rental, two Aarhus nights, the final airport night, and LEGOLAND September 13; local Öresund trains remain flexible
 
 ECCV ATTENDANCE PLAN
 • Sep 8 primary: Multimodal Digital Agents, full day
@@ -4557,15 +4657,18 @@ FLIGHTS
 OPEN DECISIONS
 • Preferred September 7 Stockholm → Malmö departure and live fare
 • Confirm Baltzar sofa-bed preparation and any property-collected mandatory fees before Sep 5
-• Exact Billund and Copenhagen room types, rates, and cancellation terms
-• Preferred direct SJ departure and both DSB Orange Fri departure times
+• Aarhus-loop versus LEGO House: giving LEGO House priority would create three consecutive one-night stays
+• Exact Aarhus and Copenhagen Airport room types, live rates, and cancellation terms
+• Rental company, car class, child-seat details, toll handling, and September 13–15 price
+• Tuesday choice: Odense, Egeskov, or a direct low-energy drive to Copenhagen Airport
+• Preferred direct SJ Stockholm → Malmö departure and live fare
 • Exact ECCV poster assignment and main-program selections
 
 CHECKLIST ITEMS COMPLETED ON THIS DEVICE
 ${selectedChecks.length ? selectedChecks.map((item) => `• ${item}`).join("\n") : "• None yet"}
 
 RESEARCH CHECKED
-August 18, 2026. Flights, Scandic Continental, and Home Hotel Baltzar are confirmed. Billund/Copenhagen lodging and the western rail plan were refreshed from official hotel and train sources; live room inventory and rates are not asserted.`;
+August 18, 2026. Flights, Scandic Continental, and Home Hotel Baltzar are confirmed. The Denmark road-loop plan, official attraction hours, CPH rental logistics, child-restraint rule, Aarhus family activities, and hotel room capacities were refreshed from primary sources; live room and car inventory or rates are not asserted.`;
     }
 
     function openExportModal() {
@@ -4618,15 +4721,16 @@ August 18, 2026. Flights, Scandic Continental, and Home Hotel Baltzar are confir
       coordinates: [[7.1, 54.1], [20.5, 54.1], [20.5, 60.75], [7.1, 60.75]]
     };
     const mapLocations = [
-      { name: "Billund", note: "2 nights · LEGO finish", coordinates: [9.1157, 55.7284], offset: [-18, -24], mobileOffset: [12, -20] },
-      { name: "Copenhagen / CPH", note: "final night + SK935", coordinates: [12.6508, 55.6181], offset: [-62, 33], mobileOffset: [-12, 44] },
+      { name: "Billund", note: "LEGOLAND stop", coordinates: [9.1157, 55.7284], offset: [-18, -24], mobileOffset: [12, -20] },
+      { name: "Aarhus", note: "2-night family base", coordinates: [10.2039, 56.1629], offset: [-22, -28], mobileOffset: [18, -24] },
+      { name: "Copenhagen / CPH", note: "rental loop + SK935", coordinates: [12.6508, 55.6181], offset: [-62, 33], mobileOffset: [-12, 44] },
       { name: "Malmö / Hyllie", note: "Baltzar + ECCV", coordinates: [12.9764, 55.5631], offset: [54, 28], mobileOffset: [22, 38] },
       { name: "Lund", note: "easy family day", coordinates: [13.1870, 55.7047], offset: [50, -30], mobileOffset: [22, -28] },
       { name: "Stockholm", note: "first 3 nights", coordinates: [18.0686, 59.3293], offset: [18, -24], mobileOffset: [-12, -18], stockholm: true }
     ];
     const coreRoute = {
       type: "LineString",
-      coordinates: [[12.9764, 55.5631], [9.1157, 55.7284], [12.6508, 55.6181]]
+      coordinates: [[12.9764, 55.5631], [12.6508, 55.6181], [9.1157, 55.7284], [10.2039, 56.1629], [12.6508, 55.6181]]
     };
     const stockholmRoute = {
       type: "LineString",


### PR DESCRIPTION
## What changed

- Reframes September 13–16 as a three-night Denmark road trip with LEGOLAND as the fixed constraint.
- Adds selectable Aarhus-loop, maximum-LEGO, and calmer Billund scenarios.
- Adds researched Aarhus activities and family-room hotel options, Funen stops, airport hotel options, and rental-car operating guidance.
- Updates the calendar, Nordic route map, booking checklist, portable trip brief, costs, and sources.

## Why

Billund has no train station, and the family wants to consider more of Denmark instead of treating all three nights as a Billund stay. A Copenhagen Airport round-trip rental creates a practical loop while protecting the confirmed nonstop flight home.

## Validation

- JavaScript syntax check
- HTML structure check with inline script and SVG excluded
- Public privacy-token scan
- Git whitespace check
